### PR TITLE
Added textType property to Word class

### DIFF
--- a/src-python/trp/__init__.py
+++ b/src-python/trp/__init__.py
@@ -84,6 +84,10 @@ class Word:
         self._text = ""
         if (block['Text']):
             self._text = block['Text']
+        self._textType = ""
+        if (block['TextType']):
+            self._textType = block['TextType']
+        
 
     def __str__(self):
         return self._text
@@ -107,6 +111,10 @@ class Word:
     @property
     def block(self):
         return self._block
+    
+    @property
+    def textType(self):
+        return self._textType
 
 
 class Line:


### PR DESCRIPTION
The purpose of this PR is to propose adding a new property to the `Word` class. It would be useful if a `.textType` property was available to ascertain whether the text identified in the textract response was `PRINTED` or `HANDWRITING`.

Please let me know if you have any ways in which I can improve the PR.

Thanks!

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
