### PR TITLE
TDocument.merge_tables and TDocument.link_tables functions for trp2.py. 

### DIFF
--- a/src-python/tests/test_trp2.py
+++ b/src-python/tests/test_trp2.py
@@ -188,12 +188,22 @@ def test_merge_tables():
     tbl_id2 = '47c6097f-02d5-4432-8423-13c05fbfacbd'
     pre_merge_tbl1_cells_no = len(t_document.get_block_by_id(tbl_id1).relationships[0].ids)
     pre_merge_tbl2_cells_no = len(t_document.get_block_by_id(tbl_id2).relationships[0].ids)
-    t_document.merge_tables([tbl_id1,tbl_id2])
+    t_document.merge_tables([[tbl_id1,tbl_id2]])
     post_merge_tbl1_cells_no = len(t_document.get_block_by_id(tbl_id1).relationships[0].ids)
-    post_merge_tbl2_cells_no = len(t_document.get_block_by_id(tbl_id2).relationships[0].ids)
-    
     assert post_merge_tbl1_cells_no == pre_merge_tbl1_cells_no + pre_merge_tbl2_cells_no
-    assert post_merge_tbl2_cells_no == pre_merge_tbl2_cells_no 
+    
+def test_delete_blocks():
+    p = os.path.dirname(os.path.realpath(__file__))
+    f = open(os.path.join(p, "data/gib_multi_page_tables.json"))
+    j = json.load(f)
+    t_document: t2.TDocument = t2.TDocumentSchema().load(j)   
+    tbl_id1 = 'fed02fb4-1996-4a15-98dc-29da193cc476'
+    tbl_id2 = '47c6097f-02d5-4432-8423-13c05fbfacbd'
+    pre_delete_block_no = len(t_document.blocks)
+    t_document.delete_blocks([tbl_id1,tbl_id2])
+    post_delete_block_no = len(t_document.blocks)
+    assert post_delete_block_no == pre_delete_block_no - 2
+
 
 def test_link_tables():
     p = os.path.dirname(os.path.realpath(__file__))
@@ -202,7 +212,6 @@ def test_link_tables():
     t_document: t2.TDocument = t2.TDocumentSchema().load(j)
     tbl_id1 = 'fed02fb4-1996-4a15-98dc-29da193cc476'
     tbl_id2 = '47c6097f-02d5-4432-8423-13c05fbfacbd'   
-    t_document.link_tables([tbl_id1,tbl_id2])
-    
+    t_document.link_tables([[tbl_id1,tbl_id2]])
     assert t_document.get_block_by_id(tbl_id1).custom['next_table']== tbl_id2
     assert t_document.get_block_by_id(tbl_id2).custom['previous_table']== tbl_id1

--- a/src-python/tests/test_trp2.py
+++ b/src-python/tests/test_trp2.py
@@ -178,3 +178,31 @@ def test_next_token_response():
     doc = t1.Document(t2.TDocumentSchema().dump(t_document))
     for page in doc.pages:
         print(page.custom['Orientation'])
+
+def test_merge_tables():
+    p = os.path.dirname(os.path.realpath(__file__))
+    f = open(os.path.join(p, "data/gib_multi_page_tables.json"))
+    j = json.load(f)
+    t_document: t2.TDocument = t2.TDocumentSchema().load(j)   
+    tbl_id1 = 'fed02fb4-1996-4a15-98dc-29da193cc476'
+    tbl_id2 = '47c6097f-02d5-4432-8423-13c05fbfacbd'
+    pre_merge_tbl1_cells_no = len(t_document.get_block_by_id(tbl_id1).relationships[0].ids)
+    pre_merge_tbl2_cells_no = len(t_document.get_block_by_id(tbl_id2).relationships[0].ids)
+    t_document.merge_tables([tbl_id1,tbl_id2])
+    post_merge_tbl1_cells_no = len(t_document.get_block_by_id(tbl_id1).relationships[0].ids)
+    post_merge_tbl2_cells_no = len(t_document.get_block_by_id(tbl_id2).relationships[0].ids)
+    
+    assert post_merge_tbl1_cells_no == pre_merge_tbl1_cells_no + pre_merge_tbl2_cells_no
+    assert post_merge_tbl2_cells_no == pre_merge_tbl2_cells_no 
+
+def test_link_tables():
+    p = os.path.dirname(os.path.realpath(__file__))
+    f = open(os.path.join(p, "data/gib_multi_page_tables.json"))
+    j = json.load(f)
+    t_document: t2.TDocument = t2.TDocumentSchema().load(j)
+    tbl_id1 = 'fed02fb4-1996-4a15-98dc-29da193cc476'
+    tbl_id2 = '47c6097f-02d5-4432-8423-13c05fbfacbd'   
+    t_document.link_tables([tbl_id1,tbl_id2])
+    
+    assert t_document.get_block_by_id(tbl_id1).custom['next_table']== tbl_id2
+    assert t_document.get_block_by_id(tbl_id2).custom['previous_table']== tbl_id1

--- a/src-python/trp/trp2.py
+++ b/src-python/trp/trp2.py
@@ -554,46 +554,48 @@ class TDocument():
         return self.__get_blocks_by_type(
             page=page, block_type_enum=TextractBlockTypes.LINE)
 
-    def merge_tables(self, table_ids):
-        child_tables = []
-        for page in self.pages:
-            tables = self.filter_blocks_by_type(
-                block_list=self.get_child_relations(page=page),
-                textract_block_type=[TextractBlockTypes.TABLE])
+    def delete_blocks(self,block_id:List[str]):
+        for b in block_id:
+            block = self.get_block_by_id(b)
+            self.blocks.remove(block)
+    
+    def merge_tables(self, table_array_ids:List[List[str]]):
+        for table_ids in table_array_ids:
+            if len(table_ids)<2:
+                raise ValueError("no parent and child tables given")
+            parent_table = self.get_block_by_id(table_ids[0])
+            if type(parent_table) is not TBlock:
+                raise ValueError("parent table is invalid")
+            table_ids.pop(0)        
+            child_tables = []
+            parent_relationships: TRelationship
+            for r in parent_table.relationships:
+                if r.type == "CHILD":
+                    parent_relationships = r
+            for table_id in table_ids:
+                child_table = self.get_block_by_id(table_id)
+                for r in child_table.relationships:
+                    if r.type == "CHILD":
+                        parent_relationships.ids.extend(cell for cell in r.ids if cell not in parent_relationships.ids)
+                self.delete_blocks([table_id])
         
-            for table in tables:
-                if table.id == table_ids[0]:
-                    parent_table = table
-                elif table.id in table_ids:
-                    child_tables.append(table)
-
-        for table in child_tables:
-            parent_table.relationships[0].ids.extend(r for r in table.relationships[0].ids if r not in parent_table.relationships[0].ids)
-
-        
-    def link_tables(self, table_ids):
-        for page in self.pages:
-            tables = self.filter_blocks_by_type(
-                block_list=self.get_child_relations(page=page),
-                textract_block_type=[TextractBlockTypes.TABLE])
-   
-            for table in tables:
-                for i in range(0,len(table_ids)):
-                    if table.id == table_ids[i]:
-                        if i>0:
-                            if table.custom:
-                                table.custom['previous_table']=table_ids[i-1]
-                            else:
-                                table.custom = {'previous_table':table_ids[i-1]}
-                    
-                        if i<len(table_ids)-1:
-                            if table.custom:
-                                table.custom['next_table']=table_ids[i+1]
-                            else:
-                                table.custom = {'next_table':table_ids[i+1]}
-
-
-
+    def link_tables(self, table_array_ids:List[List[str]]):
+        for table_ids in table_array_ids:
+            if len(table_ids)<2:
+                raise ValueError("no parent and child tables given")
+            for i in range(0,len(table_ids)):
+                table = self.get_block_by_id(table_ids[i])
+                if i>0:
+                    if table.custom:
+                        table.custom['previous_table']=table_ids[i-1]
+                    else:
+                        table.custom = {'previous_table':table_ids[i-1]}
+                if i<len(table_ids)-1:
+                    if table.custom:
+                        table.custom['next_table']=table_ids[i+1]
+                    else:
+                        table.custom = {'next_table':table_ids[i+1]}
+                        
 class THttpHeadersSchema(BaseSchema):
     date = m.fields.String(data_key="date", required=False)
     x_amzn_request_id = m.fields.String(data_key="x-amzn-requestid",

--- a/src-python/trp/trp2.py
+++ b/src-python/trp/trp2.py
@@ -554,6 +554,45 @@ class TDocument():
         return self.__get_blocks_by_type(
             page=page, block_type_enum=TextractBlockTypes.LINE)
 
+    def merge_tables(self, table_ids):
+        child_tables = []
+        for page in self.pages:
+            tables = self.filter_blocks_by_type(
+                block_list=self.get_child_relations(page=page),
+                textract_block_type=[TextractBlockTypes.TABLE])
+        
+            for table in tables:
+                if table.id == table_ids[0]:
+                    parent_table = table
+                elif table.id in table_ids:
+                    child_tables.append(table)
+
+        for table in child_tables:
+            parent_table.relationships[0].ids.extend(r for r in table.relationships[0].ids if r not in parent_table.relationships[0].ids)
+
+        
+    def link_tables(self, table_ids):
+        for page in self.pages:
+            tables = self.filter_blocks_by_type(
+                block_list=self.get_child_relations(page=page),
+                textract_block_type=[TextractBlockTypes.TABLE])
+   
+            for table in tables:
+                for i in range(0,len(table_ids)):
+                    if table.id == table_ids[i]:
+                        if i>0:
+                            if table.custom:
+                                table.custom['previous_table']=table_ids[i-1]
+                            else:
+                                table.custom = {'previous_table':table_ids[i-1]}
+                    
+                        if i<len(table_ids)-1:
+                            if table.custom:
+                                table.custom['next_table']=table_ids[i+1]
+                            else:
+                                table.custom = {'next_table':table_ids[i+1]}
+
+
 
 class THttpHeadersSchema(BaseSchema):
     date = m.fields.String(data_key="date", required=False)


### PR DESCRIPTION

*Issue #, if available:*

*Description of changes:*
merge_table functions takes an array of table_ids. It assumes the first table as the parent table and extends its cells with the cells of the other tables.
link_table functions takes an array of table_ids and create custom fields (next_table and previous_table) pointing to the the next or previous tables ids in the input array.
test_trp2.py also includes test functions for merge_table and link_table functions.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
