### PR TITLE
Update cell.row_index for merge_table

### DIFF
--- a/src-python/tests/test_trp2.py
+++ b/src-python/tests/test_trp2.py
@@ -183,14 +183,21 @@ def test_merge_tables():
     p = os.path.dirname(os.path.realpath(__file__))
     f = open(os.path.join(p, "data/gib_multi_page_tables.json"))
     j = json.load(f)
-    t_document: t2.TDocument = t2.TDocumentSchema().load(j)   
+    t_document: t2.TDocument = t2.TDocumentSchema().load(j)
     tbl_id1 = 'fed02fb4-1996-4a15-98dc-29da193cc476'
     tbl_id2 = '47c6097f-02d5-4432-8423-13c05fbfacbd'
     pre_merge_tbl1_cells_no = len(t_document.get_block_by_id(tbl_id1).relationships[0].ids)
     pre_merge_tbl2_cells_no = len(t_document.get_block_by_id(tbl_id2).relationships[0].ids)
+    pre_merge_tbl1_lastcell = t_document.get_block_by_id(tbl_id1).relationships[0].ids[-1]
+    pre_merge_tbl2_lastcell = t_document.get_block_by_id(tbl_id2).relationships[0].ids[-1]
+    pre_merge_tbl1_last_row = t_document.get_block_by_id(pre_merge_tbl1_lastcell).row_index
+    pre_merge_tbl2_last_row = t_document.get_block_by_id(pre_merge_tbl2_lastcell).row_index
     t_document.merge_tables([[tbl_id1,tbl_id2]])
     post_merge_tbl1_cells_no = len(t_document.get_block_by_id(tbl_id1).relationships[0].ids)
+    post_merge_tbl1_lastcell = t_document.get_block_by_id(tbl_id1).relationships[0].ids[-1]
+    post_merge_tbl1_last_row = t_document.get_block_by_id(post_merge_tbl1_lastcell).row_index
     assert post_merge_tbl1_cells_no == pre_merge_tbl1_cells_no + pre_merge_tbl2_cells_no
+    assert post_merge_tbl1_last_row == pre_merge_tbl1_last_row+ pre_merge_tbl2_last_row
     
 def test_delete_blocks():
     p = os.path.dirname(os.path.realpath(__file__))

--- a/src-python/tests/test_trp2.py
+++ b/src-python/tests/test_trp2.py
@@ -197,13 +197,14 @@ def test_merge_tables():
     post_merge_tbl1_lastcell = t_document.get_block_by_id(tbl_id1).relationships[0].ids[-1]
     post_merge_tbl1_last_row = t_document.get_block_by_id(post_merge_tbl1_lastcell).row_index
     assert post_merge_tbl1_cells_no == pre_merge_tbl1_cells_no + pre_merge_tbl2_cells_no
-    assert post_merge_tbl1_last_row == pre_merge_tbl1_last_row+ pre_merge_tbl2_last_row
-    
+    assert pre_merge_tbl2_last_row
+    assert post_merge_tbl1_last_row == pre_merge_tbl1_last_row + pre_merge_tbl2_last_row
+
 def test_delete_blocks():
     p = os.path.dirname(os.path.realpath(__file__))
     f = open(os.path.join(p, "data/gib_multi_page_tables.json"))
     j = json.load(f)
-    t_document: t2.TDocument = t2.TDocumentSchema().load(j)   
+    t_document: t2.TDocument = t2.TDocumentSchema().load(j)
     tbl_id1 = 'fed02fb4-1996-4a15-98dc-29da193cc476'
     tbl_id2 = '47c6097f-02d5-4432-8423-13c05fbfacbd'
     pre_delete_block_no = len(t_document.blocks)

--- a/src-python/trp/trp2.py
+++ b/src-python/trp/trp2.py
@@ -262,8 +262,6 @@ class TBlock():
     def row_index(self, value: int):
         self.__row_index = value
     
-
-
 class TBlockSchema(BaseSchema):
     block_type = m.fields.String(data_key="BlockType", allow_none=False)
     geometry = m.fields.Nested(TGeometrySchema,

--- a/src-python/trp/trp2.py
+++ b/src-python/trp/trp2.py
@@ -258,6 +258,11 @@ class TBlock():
     def custom(self, value: dict):
         self.__custom = value
 
+    @row_index.setter
+    def row_index(self, value: int):
+        self.__row_index = value
+    
+
 
 class TBlockSchema(BaseSchema):
     block_type = m.fields.String(data_key="BlockType", allow_none=False)
@@ -573,12 +578,17 @@ class TDocument():
                 if r.type == "CHILD":
                     parent_relationships = r
             for table_id in table_ids:
+                parent_last_row = self.get_block_by_id(parent_relationships.ids[-1]).row_index
                 child_table = self.get_block_by_id(table_id)
                 for r in child_table.relationships:
                     if r.type == "CHILD":
-                        parent_relationships.ids.extend(cell for cell in r.ids if cell not in parent_relationships.ids)
+                        for cell_id in r.ids:
+                            cell_block = self.get_block_by_id(cell_id)
+                            cell_block.row_index= parent_last_row + cell_block.row_index
+                            if cell_id not in parent_relationships.ids:
+                                parent_relationships.ids.append(cell_id)
                 self.delete_blocks([table_id])
-        
+
     def link_tables(self, table_array_ids:List[List[str]]):
         for table_ids in table_array_ids:
             if len(table_ids)<2:


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- Added a setter method for row_index in TBlock()
- Updated the merge_table function to update row_index after merging tables
- Updated the test merge_table function with an assertion on the row_index

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
