### PR TITLE
Update required version of marshmallow from 3.11.1 to 3.14.1

### DIFF
--- a/src-python/setup.py
+++ b/src-python/setup.py
@@ -7,7 +7,7 @@ def read(fname):
     return open(os.path.join(os.path.dirname(__file__), fname)).read()
 
 
-requirements = ['boto3', 'marshmallow==3.11.1']
+requirements = ['boto3', 'marshmallow==3.14.1']
 
 if sys.argv[-1] == 'publish-test':
     os.system(f"cd {os.path.dirname(__file__)}")


### PR DESCRIPTION
As proposed by @[StevenMapes]

marshmallow 3.11.1 was released at the end of March last year, since then various fixes have been release and so I propose upgrading the requirement to 3.14.1 which still supports Python 3.6 which will be dropped in 3.15.00. See https://github.com/marshmallow-code/marshmallow/blob/dev/CHANGELOG.rst

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
