### PR TITLE
Fix tests for indexes not being in sync

### DIFF
--- a/src-python/trp/t_pipeline.py
+++ b/src-python/trp/t_pipeline.py
@@ -22,6 +22,7 @@ def order_blocks_by_geo(t_document: t2.TDocument) -> t2.TDocument:
                              if not b.text_type == "PAGE" and b.geometry and b.geometry.bounding_box else 1)
         new_order.extend(page_blocks)
     t_document.blocks = new_order
+    t_document.__post_init__()
     return t_document
 
 

--- a/src-python/trp/trp2.py
+++ b/src-python/trp/trp2.py
@@ -606,10 +606,11 @@ class TDocument():
         return None
 
     def get_block_by_id(self, id: str) -> TBlock:
-        for b in self.blocks:
-            if b.id == id:
-                return b
-        raise ValueError(f"no block for id: {id}")
+        block = self.find_block_by_id(id=id)
+        if block:
+            return block
+        else:
+            raise ValueError(f"no block for id: {id}")
 
     def __relationships_recursive(self, block: TBlock) -> Iterator[TBlock]:
         import itertools

--- a/src-python/trp/trp2.py
+++ b/src-python/trp/trp2.py
@@ -432,6 +432,7 @@ class TResponseMetadata():
 @dataclass(eq=True, init=True, repr=True)
 class TDocument():
     document_metadata: TDocumentMetadata = field(default=None)    #type: ignore
+    # if blocks are changed, call __post_init__() to update the index
     blocks: List[TBlock] = field(default=None)    #type: ignore
     analyze_document_model_version: str = field(default=None)    #type: ignore
     detect_document_text_model_version: str = field(default=None)    #type: ignore
@@ -513,6 +514,7 @@ class TDocument():
         if not page:
             page = self.pages[0]
         page.add_ids_to_relationships(ids=[block.id])
+        self.__post_init__()
         self.relationships_recursive.cache_clear()
 
     @staticmethod
@@ -743,12 +745,11 @@ class TDocument():
         return self.get_blocks_by_type(page=page, block_type_enum=TextractBlockTypes.LINE)
 
     def delete_blocks(self, block_id: List[str]):
-        for b in block_id:
-            block = self.get_block_by_id(b)
-            if block and self.blocks:
-                self.blocks.remove(block)
-            else:
-                logger.warning(f"delete_blocks: did not get block for id: {b}")
+        # delete from high index number to low index number to avoid deleting the wrong index after removing a lower valued one
+        indexes = [self.block_id_map()[id] for id in block_id]
+        indexes.sort(reverse=True)
+        for index in indexes:
+            del self.blocks[index]
         self.__post_init__()
         self.relationships_recursive.cache_clear()
 


### PR DESCRIPTION
- fix: added hashmap access for get_block_by_id
- fix: fixes #127, keeping blocks and indexes in sync

*Issue #, if available:*
fixes #127

*Description of changes:*
Fixing delete_blocks, which deleted lower index numbers, which shifted the items and then deleted the wrong indexes
Fixing adding update of indexes after add_blocks
Fixing block ordering, which updates the index now as well

all tests work, but the design has a problem with keeping the index and the blocks array in sync. Python does not have a listener for array changes, so this is still a potential for failure if someone manipulates the TDocument.blocks array without calling __post_init__().


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
