### PR TITLE
Fix TRP.js undefined imports in front-end toolchains

### DIFF
--- a/src-js/CHANGELOG.md
+++ b/src-js/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## In development (targeting 0.2.2)
+### Changed
+- Removed `browser` field from package.json because front end bundlers like webpack use it, and the (IIFE `dist/browser`) build it pointed to was not appropriate for these build systems. Added `jsdelivr` field in its place to help ensure direct-to-browser CDN imports continue to consume the IIFE build by default.
+
 ## 0.2.1 (2023-05-22)
 ### Changed
 - `.geometry` on Expense result fields is now optional, as the underlying field may not be returned by Amazon Textract in some cases. Typings updated to reflect the fix. ([Issue #102](https://github.com/aws-samples/amazon-textract-response-parser/issues/102))

--- a/src-js/CHANGELOG.md
+++ b/src-js/CHANGELOG.md
@@ -1,11 +1,11 @@
 # Changelog
 
-## In development (targeting 0.2.2)
-### Changed
-- Removed `browser` field from package.json because front end bundlers like webpack use it, and the (IIFE `dist/browser`) build it pointed to was not appropriate for these build systems. Added `jsdelivr` field in its place to help ensure direct-to-browser CDN imports continue to consume the IIFE build by default.
+## 0.2.2 (2023-06-19)
+### Fixed
+- Removed `browser` field from package.json because front end bundlers like webpack use it, and the (IIFE `dist/browser`) build it pointed to was not appropriate for these build systems. Added `jsdelivr` field in its place to help ensure direct-to-browser CDN imports continue to consume the IIFE build by default. ([Issue #139](https://github.com/aws-samples/amazon-textract-response-parser/issues/139))
 
 ## 0.2.1 (2023-05-22)
-### Changed
+### Fixed
 - `.geometry` on Expense result fields is now optional, as the underlying field may not be returned by Amazon Textract in some cases. Typings updated to reflect the fix. ([Issue #102](https://github.com/aws-samples/amazon-textract-response-parser/issues/102))
 
 ## 0.2.0 (2022-04-28)

--- a/src-js/README.md
+++ b/src-js/README.md
@@ -35,7 +35,7 @@ At a low level, the distribution of this library provides multiple builds:
 
 - `dist/cjs` (default `main`), for CommonJS environments like NodeJS,
 - `dist/es` (default `module`), for ES6/ES2015/esnext capable environments,
-- `dist/browser` (default `browser`), for use directly in the browser with no module framework (IIFE), and
+- `dist/browser` (default `jsdelivr` and `unpkg`), for use directly in the browser with no module framework (IIFE), and
 - **(Deprecated):** `dist/umd`, for other [Universal Module Definition](https://github.com/umdjs/umd)-compatible environments. This build is slated to be removed in a future release so please let us know via GitHub issues if you have blockers for migrating to another build.
 
 ## Loading data

--- a/src-js/package-lock.json
+++ b/src-js/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "amazon-textract-response-parser",
-  "version": "0.2.2-alpha.1",
+  "version": "0.2.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "amazon-textract-response-parser",
-      "version": "0.2.2-alpha.1",
+      "version": "0.2.2",
       "license": "Apache-2.0",
       "devDependencies": {
         "@aws-sdk/client-textract": "^3.43.0",
@@ -42,6 +42,23 @@
       "engines": {
         "node": ">=6.0.0"
       }
+    },
+    "node_modules/@aws-crypto/crc32": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/crc32/-/crc32-3.0.0.tgz",
+      "integrity": "sha512-IzSgsrxUcsrejQbPVilIKy16kAT52EwB6zSaI+M3xxIhKh5+aldEyvI+z6erM7TCLB2BJsFrtHjp6/4/sr+3dA==",
+      "dev": true,
+      "dependencies": {
+        "@aws-crypto/util": "^3.0.0",
+        "@aws-sdk/types": "^3.222.0",
+        "tslib": "^1.11.1"
+      }
+    },
+    "node_modules/@aws-crypto/crc32/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+      "dev": true
     },
     "node_modules/@aws-crypto/ie11-detection": {
       "version": "3.0.0",
@@ -130,12 +147,12 @@
       "dev": true
     },
     "node_modules/@aws-sdk/abort-controller": {
-      "version": "3.329.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/abort-controller/-/abort-controller-3.329.0.tgz",
-      "integrity": "sha512-hzrjPNQcJoSPe0oS20V5i98oiEZSM3mKNiR6P3xHTHTPI/F23lyjGZ+/CSkCmJbSWfGZ5sHZZcU6AWuS7xBdTw==",
+      "version": "3.347.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/abort-controller/-/abort-controller-3.347.0.tgz",
+      "integrity": "sha512-P/2qE6ntYEmYG4Ez535nJWZbXqgbkJx8CMz7ChEuEg3Gp3dvVYEKg+iEUEvlqQ2U5dWP5J3ehw5po9t86IsVPQ==",
       "dev": true,
       "dependencies": {
-        "@aws-sdk/types": "3.329.0",
+        "@aws-sdk/types": "3.347.0",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -143,42 +160,43 @@
       }
     },
     "node_modules/@aws-sdk/client-sso": {
-      "version": "3.329.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.329.0.tgz",
-      "integrity": "sha512-RzUEbXg+01PRD3UbFJlCNA51JYRZ9qGUSWRPVeQ6zR4RKx8146/xeL2j8CHEZbGQrRNoHvBziGSCxIdTpzM8XA==",
+      "version": "3.354.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.354.0.tgz",
+      "integrity": "sha512-4jmvjJYDaaPmm1n2TG4LYfTEnHLKcJmImgBqhgzhMgaypb4u/k1iw0INV2r/afYPL/FsrLFwc46RM3HYx3nc4A==",
       "dev": true,
       "dependencies": {
         "@aws-crypto/sha256-browser": "3.0.0",
         "@aws-crypto/sha256-js": "3.0.0",
-        "@aws-sdk/config-resolver": "3.329.0",
-        "@aws-sdk/fetch-http-handler": "3.329.0",
-        "@aws-sdk/hash-node": "3.329.0",
-        "@aws-sdk/invalid-dependency": "3.329.0",
-        "@aws-sdk/middleware-content-length": "3.329.0",
-        "@aws-sdk/middleware-endpoint": "3.329.0",
-        "@aws-sdk/middleware-host-header": "3.329.0",
-        "@aws-sdk/middleware-logger": "3.329.0",
-        "@aws-sdk/middleware-recursion-detection": "3.329.0",
-        "@aws-sdk/middleware-retry": "3.329.0",
-        "@aws-sdk/middleware-serde": "3.329.0",
-        "@aws-sdk/middleware-stack": "3.329.0",
-        "@aws-sdk/middleware-user-agent": "3.329.0",
-        "@aws-sdk/node-config-provider": "3.329.0",
-        "@aws-sdk/node-http-handler": "3.329.0",
-        "@aws-sdk/protocol-http": "3.329.0",
-        "@aws-sdk/smithy-client": "3.329.0",
-        "@aws-sdk/types": "3.329.0",
-        "@aws-sdk/url-parser": "3.329.0",
+        "@aws-sdk/config-resolver": "3.354.0",
+        "@aws-sdk/fetch-http-handler": "3.353.0",
+        "@aws-sdk/hash-node": "3.347.0",
+        "@aws-sdk/invalid-dependency": "3.347.0",
+        "@aws-sdk/middleware-content-length": "3.347.0",
+        "@aws-sdk/middleware-endpoint": "3.347.0",
+        "@aws-sdk/middleware-host-header": "3.347.0",
+        "@aws-sdk/middleware-logger": "3.347.0",
+        "@aws-sdk/middleware-recursion-detection": "3.347.0",
+        "@aws-sdk/middleware-retry": "3.354.0",
+        "@aws-sdk/middleware-serde": "3.347.0",
+        "@aws-sdk/middleware-stack": "3.347.0",
+        "@aws-sdk/middleware-user-agent": "3.352.0",
+        "@aws-sdk/node-config-provider": "3.354.0",
+        "@aws-sdk/node-http-handler": "3.350.0",
+        "@aws-sdk/smithy-client": "3.347.0",
+        "@aws-sdk/types": "3.347.0",
+        "@aws-sdk/url-parser": "3.347.0",
         "@aws-sdk/util-base64": "3.310.0",
         "@aws-sdk/util-body-length-browser": "3.310.0",
         "@aws-sdk/util-body-length-node": "3.310.0",
-        "@aws-sdk/util-defaults-mode-browser": "3.329.0",
-        "@aws-sdk/util-defaults-mode-node": "3.329.0",
-        "@aws-sdk/util-endpoints": "3.329.0",
-        "@aws-sdk/util-retry": "3.329.0",
-        "@aws-sdk/util-user-agent-browser": "3.329.0",
-        "@aws-sdk/util-user-agent-node": "3.329.0",
+        "@aws-sdk/util-defaults-mode-browser": "3.353.0",
+        "@aws-sdk/util-defaults-mode-node": "3.354.0",
+        "@aws-sdk/util-endpoints": "3.352.0",
+        "@aws-sdk/util-retry": "3.347.0",
+        "@aws-sdk/util-user-agent-browser": "3.347.0",
+        "@aws-sdk/util-user-agent-node": "3.354.0",
         "@aws-sdk/util-utf8": "3.310.0",
+        "@smithy/protocol-http": "^1.0.1",
+        "@smithy/types": "^1.0.0",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -186,42 +204,43 @@
       }
     },
     "node_modules/@aws-sdk/client-sso-oidc": {
-      "version": "3.329.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.329.0.tgz",
-      "integrity": "sha512-Dv0TMHcMLqkN43QbQsFYDjVI5Lb7ta+jQUC72H1pA0Z/EMRSKX/aaKIrH9TsnMqRPv57+SwUMw7i6yDIqR9nNg==",
+      "version": "3.354.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.354.0.tgz",
+      "integrity": "sha512-XZcg4s2zKb4S8ltluiw5yxpm974uZqzo2HTECt1lbzUJgVgLsMAh/nPJ1fLqg4jadT+rf8Lq2FEFqOM/vxWT8A==",
       "dev": true,
       "dependencies": {
         "@aws-crypto/sha256-browser": "3.0.0",
         "@aws-crypto/sha256-js": "3.0.0",
-        "@aws-sdk/config-resolver": "3.329.0",
-        "@aws-sdk/fetch-http-handler": "3.329.0",
-        "@aws-sdk/hash-node": "3.329.0",
-        "@aws-sdk/invalid-dependency": "3.329.0",
-        "@aws-sdk/middleware-content-length": "3.329.0",
-        "@aws-sdk/middleware-endpoint": "3.329.0",
-        "@aws-sdk/middleware-host-header": "3.329.0",
-        "@aws-sdk/middleware-logger": "3.329.0",
-        "@aws-sdk/middleware-recursion-detection": "3.329.0",
-        "@aws-sdk/middleware-retry": "3.329.0",
-        "@aws-sdk/middleware-serde": "3.329.0",
-        "@aws-sdk/middleware-stack": "3.329.0",
-        "@aws-sdk/middleware-user-agent": "3.329.0",
-        "@aws-sdk/node-config-provider": "3.329.0",
-        "@aws-sdk/node-http-handler": "3.329.0",
-        "@aws-sdk/protocol-http": "3.329.0",
-        "@aws-sdk/smithy-client": "3.329.0",
-        "@aws-sdk/types": "3.329.0",
-        "@aws-sdk/url-parser": "3.329.0",
+        "@aws-sdk/config-resolver": "3.354.0",
+        "@aws-sdk/fetch-http-handler": "3.353.0",
+        "@aws-sdk/hash-node": "3.347.0",
+        "@aws-sdk/invalid-dependency": "3.347.0",
+        "@aws-sdk/middleware-content-length": "3.347.0",
+        "@aws-sdk/middleware-endpoint": "3.347.0",
+        "@aws-sdk/middleware-host-header": "3.347.0",
+        "@aws-sdk/middleware-logger": "3.347.0",
+        "@aws-sdk/middleware-recursion-detection": "3.347.0",
+        "@aws-sdk/middleware-retry": "3.354.0",
+        "@aws-sdk/middleware-serde": "3.347.0",
+        "@aws-sdk/middleware-stack": "3.347.0",
+        "@aws-sdk/middleware-user-agent": "3.352.0",
+        "@aws-sdk/node-config-provider": "3.354.0",
+        "@aws-sdk/node-http-handler": "3.350.0",
+        "@aws-sdk/smithy-client": "3.347.0",
+        "@aws-sdk/types": "3.347.0",
+        "@aws-sdk/url-parser": "3.347.0",
         "@aws-sdk/util-base64": "3.310.0",
         "@aws-sdk/util-body-length-browser": "3.310.0",
         "@aws-sdk/util-body-length-node": "3.310.0",
-        "@aws-sdk/util-defaults-mode-browser": "3.329.0",
-        "@aws-sdk/util-defaults-mode-node": "3.329.0",
-        "@aws-sdk/util-endpoints": "3.329.0",
-        "@aws-sdk/util-retry": "3.329.0",
-        "@aws-sdk/util-user-agent-browser": "3.329.0",
-        "@aws-sdk/util-user-agent-node": "3.329.0",
+        "@aws-sdk/util-defaults-mode-browser": "3.353.0",
+        "@aws-sdk/util-defaults-mode-node": "3.354.0",
+        "@aws-sdk/util-endpoints": "3.352.0",
+        "@aws-sdk/util-retry": "3.347.0",
+        "@aws-sdk/util-user-agent-browser": "3.347.0",
+        "@aws-sdk/util-user-agent-node": "3.354.0",
         "@aws-sdk/util-utf8": "3.310.0",
+        "@smithy/protocol-http": "^1.0.1",
+        "@smithy/types": "^1.0.0",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -229,46 +248,47 @@
       }
     },
     "node_modules/@aws-sdk/client-sts": {
-      "version": "3.329.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.329.0.tgz",
-      "integrity": "sha512-bJ8Uoi0v5gzjw8BUYZcd0gDQ6nbHHBjDedBdXzBjV4z8b8whaCOyyASPCLZ9COKdgpkm1kHz9z5IX1cB4Q2nfA==",
+      "version": "3.354.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.354.0.tgz",
+      "integrity": "sha512-l9Ar/C/3PNlToM1ukHVfBtp4plbRUxLMYY2DOTMI0nb3jzfcvETBcdEGCP51fX4uAfJ2vc4g5qBF/qXKX0LMWA==",
       "dev": true,
       "dependencies": {
         "@aws-crypto/sha256-browser": "3.0.0",
         "@aws-crypto/sha256-js": "3.0.0",
-        "@aws-sdk/config-resolver": "3.329.0",
-        "@aws-sdk/credential-provider-node": "3.329.0",
-        "@aws-sdk/fetch-http-handler": "3.329.0",
-        "@aws-sdk/hash-node": "3.329.0",
-        "@aws-sdk/invalid-dependency": "3.329.0",
-        "@aws-sdk/middleware-content-length": "3.329.0",
-        "@aws-sdk/middleware-endpoint": "3.329.0",
-        "@aws-sdk/middleware-host-header": "3.329.0",
-        "@aws-sdk/middleware-logger": "3.329.0",
-        "@aws-sdk/middleware-recursion-detection": "3.329.0",
-        "@aws-sdk/middleware-retry": "3.329.0",
-        "@aws-sdk/middleware-sdk-sts": "3.329.0",
-        "@aws-sdk/middleware-serde": "3.329.0",
-        "@aws-sdk/middleware-signing": "3.329.0",
-        "@aws-sdk/middleware-stack": "3.329.0",
-        "@aws-sdk/middleware-user-agent": "3.329.0",
-        "@aws-sdk/node-config-provider": "3.329.0",
-        "@aws-sdk/node-http-handler": "3.329.0",
-        "@aws-sdk/protocol-http": "3.329.0",
-        "@aws-sdk/smithy-client": "3.329.0",
-        "@aws-sdk/types": "3.329.0",
-        "@aws-sdk/url-parser": "3.329.0",
+        "@aws-sdk/config-resolver": "3.354.0",
+        "@aws-sdk/credential-provider-node": "3.354.0",
+        "@aws-sdk/fetch-http-handler": "3.353.0",
+        "@aws-sdk/hash-node": "3.347.0",
+        "@aws-sdk/invalid-dependency": "3.347.0",
+        "@aws-sdk/middleware-content-length": "3.347.0",
+        "@aws-sdk/middleware-endpoint": "3.347.0",
+        "@aws-sdk/middleware-host-header": "3.347.0",
+        "@aws-sdk/middleware-logger": "3.347.0",
+        "@aws-sdk/middleware-recursion-detection": "3.347.0",
+        "@aws-sdk/middleware-retry": "3.354.0",
+        "@aws-sdk/middleware-sdk-sts": "3.354.0",
+        "@aws-sdk/middleware-serde": "3.347.0",
+        "@aws-sdk/middleware-signing": "3.354.0",
+        "@aws-sdk/middleware-stack": "3.347.0",
+        "@aws-sdk/middleware-user-agent": "3.352.0",
+        "@aws-sdk/node-config-provider": "3.354.0",
+        "@aws-sdk/node-http-handler": "3.350.0",
+        "@aws-sdk/smithy-client": "3.347.0",
+        "@aws-sdk/types": "3.347.0",
+        "@aws-sdk/url-parser": "3.347.0",
         "@aws-sdk/util-base64": "3.310.0",
         "@aws-sdk/util-body-length-browser": "3.310.0",
         "@aws-sdk/util-body-length-node": "3.310.0",
-        "@aws-sdk/util-defaults-mode-browser": "3.329.0",
-        "@aws-sdk/util-defaults-mode-node": "3.329.0",
-        "@aws-sdk/util-endpoints": "3.329.0",
-        "@aws-sdk/util-retry": "3.329.0",
-        "@aws-sdk/util-user-agent-browser": "3.329.0",
-        "@aws-sdk/util-user-agent-node": "3.329.0",
+        "@aws-sdk/util-defaults-mode-browser": "3.353.0",
+        "@aws-sdk/util-defaults-mode-node": "3.354.0",
+        "@aws-sdk/util-endpoints": "3.352.0",
+        "@aws-sdk/util-retry": "3.347.0",
+        "@aws-sdk/util-user-agent-browser": "3.347.0",
+        "@aws-sdk/util-user-agent-node": "3.354.0",
         "@aws-sdk/util-utf8": "3.310.0",
-        "fast-xml-parser": "4.1.2",
+        "@smithy/protocol-http": "^1.0.1",
+        "@smithy/types": "^1.0.0",
+        "fast-xml-parser": "4.2.4",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -276,45 +296,46 @@
       }
     },
     "node_modules/@aws-sdk/client-textract": {
-      "version": "3.329.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-textract/-/client-textract-3.329.0.tgz",
-      "integrity": "sha512-whffjTjiXcEnCs4XXlhph76DGHUCnR4d1cDmQGA5EMEyxzOKCkLt9rfLW3Fq0wnjxBarQ1jnnfgkurYHqa21sQ==",
+      "version": "3.354.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-textract/-/client-textract-3.354.0.tgz",
+      "integrity": "sha512-1uHnMl6zbbTzri3mTDf88CBkyEOlAoLpDwHp0UB1XYcCm+c1zKxxMKlOUiKcXdZWpvGjXmjhaH9pXSSksX75jg==",
       "dev": true,
       "dependencies": {
         "@aws-crypto/sha256-browser": "3.0.0",
         "@aws-crypto/sha256-js": "3.0.0",
-        "@aws-sdk/client-sts": "3.329.0",
-        "@aws-sdk/config-resolver": "3.329.0",
-        "@aws-sdk/credential-provider-node": "3.329.0",
-        "@aws-sdk/fetch-http-handler": "3.329.0",
-        "@aws-sdk/hash-node": "3.329.0",
-        "@aws-sdk/invalid-dependency": "3.329.0",
-        "@aws-sdk/middleware-content-length": "3.329.0",
-        "@aws-sdk/middleware-endpoint": "3.329.0",
-        "@aws-sdk/middleware-host-header": "3.329.0",
-        "@aws-sdk/middleware-logger": "3.329.0",
-        "@aws-sdk/middleware-recursion-detection": "3.329.0",
-        "@aws-sdk/middleware-retry": "3.329.0",
-        "@aws-sdk/middleware-serde": "3.329.0",
-        "@aws-sdk/middleware-signing": "3.329.0",
-        "@aws-sdk/middleware-stack": "3.329.0",
-        "@aws-sdk/middleware-user-agent": "3.329.0",
-        "@aws-sdk/node-config-provider": "3.329.0",
-        "@aws-sdk/node-http-handler": "3.329.0",
-        "@aws-sdk/protocol-http": "3.329.0",
-        "@aws-sdk/smithy-client": "3.329.0",
-        "@aws-sdk/types": "3.329.0",
-        "@aws-sdk/url-parser": "3.329.0",
+        "@aws-sdk/client-sts": "3.354.0",
+        "@aws-sdk/config-resolver": "3.354.0",
+        "@aws-sdk/credential-provider-node": "3.354.0",
+        "@aws-sdk/fetch-http-handler": "3.353.0",
+        "@aws-sdk/hash-node": "3.347.0",
+        "@aws-sdk/invalid-dependency": "3.347.0",
+        "@aws-sdk/middleware-content-length": "3.347.0",
+        "@aws-sdk/middleware-endpoint": "3.347.0",
+        "@aws-sdk/middleware-host-header": "3.347.0",
+        "@aws-sdk/middleware-logger": "3.347.0",
+        "@aws-sdk/middleware-recursion-detection": "3.347.0",
+        "@aws-sdk/middleware-retry": "3.354.0",
+        "@aws-sdk/middleware-serde": "3.347.0",
+        "@aws-sdk/middleware-signing": "3.354.0",
+        "@aws-sdk/middleware-stack": "3.347.0",
+        "@aws-sdk/middleware-user-agent": "3.352.0",
+        "@aws-sdk/node-config-provider": "3.354.0",
+        "@aws-sdk/node-http-handler": "3.350.0",
+        "@aws-sdk/smithy-client": "3.347.0",
+        "@aws-sdk/types": "3.347.0",
+        "@aws-sdk/url-parser": "3.347.0",
         "@aws-sdk/util-base64": "3.310.0",
         "@aws-sdk/util-body-length-browser": "3.310.0",
         "@aws-sdk/util-body-length-node": "3.310.0",
-        "@aws-sdk/util-defaults-mode-browser": "3.329.0",
-        "@aws-sdk/util-defaults-mode-node": "3.329.0",
-        "@aws-sdk/util-endpoints": "3.329.0",
-        "@aws-sdk/util-retry": "3.329.0",
-        "@aws-sdk/util-user-agent-browser": "3.329.0",
-        "@aws-sdk/util-user-agent-node": "3.329.0",
+        "@aws-sdk/util-defaults-mode-browser": "3.353.0",
+        "@aws-sdk/util-defaults-mode-node": "3.354.0",
+        "@aws-sdk/util-endpoints": "3.352.0",
+        "@aws-sdk/util-retry": "3.347.0",
+        "@aws-sdk/util-user-agent-browser": "3.347.0",
+        "@aws-sdk/util-user-agent-node": "3.354.0",
         "@aws-sdk/util-utf8": "3.310.0",
+        "@smithy/protocol-http": "^1.0.1",
+        "@smithy/types": "^1.0.0",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -322,14 +343,14 @@
       }
     },
     "node_modules/@aws-sdk/config-resolver": {
-      "version": "3.329.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/config-resolver/-/config-resolver-3.329.0.tgz",
-      "integrity": "sha512-Oj6eiT3q+Jn685yvUrfRi8PhB3fb81hasJqdrsEivA8IP8qAgnVUTJzXsh8O2UX8UM2MF6A1gTgToSgneJuw2Q==",
+      "version": "3.354.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/config-resolver/-/config-resolver-3.354.0.tgz",
+      "integrity": "sha512-K4XWie8yJPT8bpYVX54VJMQhiJRTw8PrjEs9QrKqvwoCcZ3G4qEt40tIu33XksuokXxk8rrVH5d7odOPBsAtdg==",
       "dev": true,
       "dependencies": {
-        "@aws-sdk/types": "3.329.0",
+        "@aws-sdk/types": "3.347.0",
         "@aws-sdk/util-config-provider": "3.310.0",
-        "@aws-sdk/util-middleware": "3.329.0",
+        "@aws-sdk/util-middleware": "3.347.0",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -337,13 +358,13 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-env": {
-      "version": "3.329.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.329.0.tgz",
-      "integrity": "sha512-B4orC9hMt9hG82vAR0TAnQqjk6cFDbO2S14RdzUj2n2NPlGWW4Blkv3NTo86K0lq011VRhtqaLcuTwn5EJD5Sg==",
+      "version": "3.353.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.353.0.tgz",
+      "integrity": "sha512-Y4VsNS8O1FAD5J7S5itOhnOghQ5LIXlZ44t35nF8cbcF+JPvY3ToKzYpjYN1jM7DXKqU4shtqgYpzSqxlvEgKQ==",
       "dev": true,
       "dependencies": {
-        "@aws-sdk/property-provider": "3.329.0",
-        "@aws-sdk/types": "3.329.0",
+        "@aws-sdk/property-provider": "3.353.0",
+        "@aws-sdk/types": "3.347.0",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -351,15 +372,15 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-imds": {
-      "version": "3.329.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-imds/-/credential-provider-imds-3.329.0.tgz",
-      "integrity": "sha512-ggPlnd7QROPTid0CwT01TYYGvstRRTpzTGsQ/B31wkh30IrRXE81W3S4xrOYuqQD3u0RnflSxnvhs+EayJEYjg==",
+      "version": "3.354.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-imds/-/credential-provider-imds-3.354.0.tgz",
+      "integrity": "sha512-AB+PuDd1jX6qgz+JYvIyOn8Kz9/lQ60KuY1TFb7g3S8zURw+DSeMJNR1jzEsorWICTzhxXmyasHVMa4Eo4Uq+Q==",
       "dev": true,
       "dependencies": {
-        "@aws-sdk/node-config-provider": "3.329.0",
-        "@aws-sdk/property-provider": "3.329.0",
-        "@aws-sdk/types": "3.329.0",
-        "@aws-sdk/url-parser": "3.329.0",
+        "@aws-sdk/node-config-provider": "3.354.0",
+        "@aws-sdk/property-provider": "3.353.0",
+        "@aws-sdk/types": "3.347.0",
+        "@aws-sdk/url-parser": "3.347.0",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -367,19 +388,19 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-ini": {
-      "version": "3.329.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.329.0.tgz",
-      "integrity": "sha512-dtSYWPTKh4VHG2ooLIBT9XfFab7hdaNF0z6kFEPsZcecpeO7iAkxu57/xkB2KMXCi8Hy9qQUf+M9N4xDxEujVA==",
+      "version": "3.354.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.354.0.tgz",
+      "integrity": "sha512-bn2ifrRsxWpxzwXa25jRdUECQ1dC+NB3YlRYnGdIaIQLF559N2jnfCabYzqyfKI++WU7aQeMofPe2PxVGlbv9Q==",
       "dev": true,
       "dependencies": {
-        "@aws-sdk/credential-provider-env": "3.329.0",
-        "@aws-sdk/credential-provider-imds": "3.329.0",
-        "@aws-sdk/credential-provider-process": "3.329.0",
-        "@aws-sdk/credential-provider-sso": "3.329.0",
-        "@aws-sdk/credential-provider-web-identity": "3.329.0",
-        "@aws-sdk/property-provider": "3.329.0",
-        "@aws-sdk/shared-ini-file-loader": "3.329.0",
-        "@aws-sdk/types": "3.329.0",
+        "@aws-sdk/credential-provider-env": "3.353.0",
+        "@aws-sdk/credential-provider-imds": "3.354.0",
+        "@aws-sdk/credential-provider-process": "3.354.0",
+        "@aws-sdk/credential-provider-sso": "3.354.0",
+        "@aws-sdk/credential-provider-web-identity": "3.354.0",
+        "@aws-sdk/property-provider": "3.353.0",
+        "@aws-sdk/shared-ini-file-loader": "3.354.0",
+        "@aws-sdk/types": "3.347.0",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -387,20 +408,20 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-node": {
-      "version": "3.329.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.329.0.tgz",
-      "integrity": "sha512-JTTn7H8p4j7EciCgoJdSwOSt843PmlL1BXoo61l2IE9novM9ZtCiU7VipuGEe7gFBfu+84UCAJh2D7Vp/KI9DA==",
+      "version": "3.354.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.354.0.tgz",
+      "integrity": "sha512-ltKiRtHfqDaCcrb44DIoSHQ9MposFl/aDtNdu5OdQv/2Q1r7M/r2fQdq9DHOrxeQQjaUH4C6k6fGTsxALTHyNA==",
       "dev": true,
       "dependencies": {
-        "@aws-sdk/credential-provider-env": "3.329.0",
-        "@aws-sdk/credential-provider-imds": "3.329.0",
-        "@aws-sdk/credential-provider-ini": "3.329.0",
-        "@aws-sdk/credential-provider-process": "3.329.0",
-        "@aws-sdk/credential-provider-sso": "3.329.0",
-        "@aws-sdk/credential-provider-web-identity": "3.329.0",
-        "@aws-sdk/property-provider": "3.329.0",
-        "@aws-sdk/shared-ini-file-loader": "3.329.0",
-        "@aws-sdk/types": "3.329.0",
+        "@aws-sdk/credential-provider-env": "3.353.0",
+        "@aws-sdk/credential-provider-imds": "3.354.0",
+        "@aws-sdk/credential-provider-ini": "3.354.0",
+        "@aws-sdk/credential-provider-process": "3.354.0",
+        "@aws-sdk/credential-provider-sso": "3.354.0",
+        "@aws-sdk/credential-provider-web-identity": "3.354.0",
+        "@aws-sdk/property-provider": "3.353.0",
+        "@aws-sdk/shared-ini-file-loader": "3.354.0",
+        "@aws-sdk/types": "3.347.0",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -408,14 +429,14 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-process": {
-      "version": "3.329.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.329.0.tgz",
-      "integrity": "sha512-5oO220qoFc2pMdZDQa6XN/mVhp669I3+LqMbbscGtX/UgLJPSOb7YzPld9Wjv12L5rf+sD3G1PF3LZXO0vKLFA==",
+      "version": "3.354.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.354.0.tgz",
+      "integrity": "sha512-AxpASm+tS8V1PY4PLfG9dtqa96lzBJ3niTQb+RAm4uYCddW7gxNDkGB+jSCzVdUPVa3xA2ITBS/ka3C5yM8YWg==",
       "dev": true,
       "dependencies": {
-        "@aws-sdk/property-provider": "3.329.0",
-        "@aws-sdk/shared-ini-file-loader": "3.329.0",
-        "@aws-sdk/types": "3.329.0",
+        "@aws-sdk/property-provider": "3.353.0",
+        "@aws-sdk/shared-ini-file-loader": "3.354.0",
+        "@aws-sdk/types": "3.347.0",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -423,16 +444,16 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-sso": {
-      "version": "3.329.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.329.0.tgz",
-      "integrity": "sha512-R/TICn1Aty4PMvRXr7h8skWJ1rGF5CXWb0U63GhOyn23IE5FAkqzMhJLbXo/AYD8dQeMLrf03qVIEAs/B0d7mA==",
+      "version": "3.354.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.354.0.tgz",
+      "integrity": "sha512-ihiaUxh8V/nQgTOgQZxWQcbckXhM+J6Wdc4F0z9soi48iSOqzRpzPw5E14wSZScEZjNY/gKEDz8gCt8WkT/G0w==",
       "dev": true,
       "dependencies": {
-        "@aws-sdk/client-sso": "3.329.0",
-        "@aws-sdk/property-provider": "3.329.0",
-        "@aws-sdk/shared-ini-file-loader": "3.329.0",
-        "@aws-sdk/token-providers": "3.329.0",
-        "@aws-sdk/types": "3.329.0",
+        "@aws-sdk/client-sso": "3.354.0",
+        "@aws-sdk/property-provider": "3.353.0",
+        "@aws-sdk/shared-ini-file-loader": "3.354.0",
+        "@aws-sdk/token-providers": "3.354.0",
+        "@aws-sdk/types": "3.347.0",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -440,39 +461,51 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-web-identity": {
-      "version": "3.329.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.329.0.tgz",
-      "integrity": "sha512-lcEibZD7AlutCacpQ6DyNUqElZJDq+ylaIo5a8MH9jGh7Pg2WpDg0Sy+B6FbGCkVn4eIjdHxeX54JM245nhESg==",
+      "version": "3.354.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.354.0.tgz",
+      "integrity": "sha512-scx9mAf4m3Hc3uMX2Vh8GciEcC/5GqeDI8qc0zBj+UF/5c/GtihZA4WoCV3Sg3jMPDUKY81DiFCtcKHhtUqKfg==",
       "dev": true,
       "dependencies": {
-        "@aws-sdk/property-provider": "3.329.0",
-        "@aws-sdk/types": "3.329.0",
+        "@aws-sdk/property-provider": "3.353.0",
+        "@aws-sdk/types": "3.347.0",
         "tslib": "^2.5.0"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
-    "node_modules/@aws-sdk/fetch-http-handler": {
-      "version": "3.329.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/fetch-http-handler/-/fetch-http-handler-3.329.0.tgz",
-      "integrity": "sha512-9jfIeJhYCcTX4ScXOueRTB3S/tVce0bRsKxKDP0PnTxnGYOwKXoM9lAPmiYItzYmQ/+QzjTI8xfkA9Usz2SK/Q==",
+    "node_modules/@aws-sdk/eventstream-codec": {
+      "version": "3.347.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-codec/-/eventstream-codec-3.347.0.tgz",
+      "integrity": "sha512-61q+SyspjsaQ4sdgjizMyRgVph2CiW4aAtfpoH69EJFJfTxTR/OqnZ9Jx/3YiYi0ksrvDenJddYodfWWJqD8/w==",
       "dev": true,
       "dependencies": {
-        "@aws-sdk/protocol-http": "3.329.0",
-        "@aws-sdk/querystring-builder": "3.329.0",
-        "@aws-sdk/types": "3.329.0",
+        "@aws-crypto/crc32": "3.0.0",
+        "@aws-sdk/types": "3.347.0",
+        "@aws-sdk/util-hex-encoding": "3.310.0",
+        "tslib": "^2.5.0"
+      }
+    },
+    "node_modules/@aws-sdk/fetch-http-handler": {
+      "version": "3.353.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/fetch-http-handler/-/fetch-http-handler-3.353.0.tgz",
+      "integrity": "sha512-8ic2+4E6jzfDevd++QS1rOR05QFkAhEFbi5Ja3/Zzp7TkWIS8wv5wwMATjNkbbdsXYuB5Lhl/OsjfZmIv5aqRw==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/protocol-http": "3.347.0",
+        "@aws-sdk/querystring-builder": "3.347.0",
+        "@aws-sdk/types": "3.347.0",
         "@aws-sdk/util-base64": "3.310.0",
         "tslib": "^2.5.0"
       }
     },
     "node_modules/@aws-sdk/hash-node": {
-      "version": "3.329.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/hash-node/-/hash-node-3.329.0.tgz",
-      "integrity": "sha512-6RmnWXNWpi7yAs0oRDQlkMn2wfXOStr/8kTCgiAiqrk1KopGSBkC2veKiKRSfv02FTd1yV/ISqYNIRqW1VLyxg==",
+      "version": "3.347.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/hash-node/-/hash-node-3.347.0.tgz",
+      "integrity": "sha512-96+ml/4EaUaVpzBdOLGOxdoXOjkPgkoJp/0i1fxOJEvl8wdAQSwc3IugVK9wZkCxy2DlENtgOe6DfIOhfffm/g==",
       "dev": true,
       "dependencies": {
-        "@aws-sdk/types": "3.329.0",
+        "@aws-sdk/types": "3.347.0",
         "@aws-sdk/util-buffer-from": "3.310.0",
         "@aws-sdk/util-utf8": "3.310.0",
         "tslib": "^2.5.0"
@@ -482,12 +515,12 @@
       }
     },
     "node_modules/@aws-sdk/invalid-dependency": {
-      "version": "3.329.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/invalid-dependency/-/invalid-dependency-3.329.0.tgz",
-      "integrity": "sha512-UXynGusDxN/HxLma5ByJ7u+XnuMd47NbHOjJgYsaAjb1CVZT7hEPXOB+mcZ+Ku7To5SCOKu2QbRn7m4bGespBg==",
+      "version": "3.347.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/invalid-dependency/-/invalid-dependency-3.347.0.tgz",
+      "integrity": "sha512-8imQcwLwqZ/wTJXZqzXT9pGLIksTRckhGLZaXT60tiBOPKuerTsus2L59UstLs5LP8TKaVZKFFSsjRIn9dQdmQ==",
       "dev": true,
       "dependencies": {
-        "@aws-sdk/types": "3.329.0",
+        "@aws-sdk/types": "3.347.0",
         "tslib": "^2.5.0"
       }
     },
@@ -504,13 +537,13 @@
       }
     },
     "node_modules/@aws-sdk/middleware-content-length": {
-      "version": "3.329.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-content-length/-/middleware-content-length-3.329.0.tgz",
-      "integrity": "sha512-7kCd+CvY/4KbyXB0uyL7jCwPjMi2yERMALFdEH9dsUciwmxIQT6eSc4aF6wImC4UrbafaqmXvvHErABKMVBTKA==",
+      "version": "3.347.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-content-length/-/middleware-content-length-3.347.0.tgz",
+      "integrity": "sha512-i4qtWTDImMaDUtwKQPbaZpXsReiwiBomM1cWymCU4bhz81HL01oIxOxOBuiM+3NlDoCSPr3KI6txZSz/8cqXCQ==",
       "dev": true,
       "dependencies": {
-        "@aws-sdk/protocol-http": "3.329.0",
-        "@aws-sdk/types": "3.329.0",
+        "@aws-sdk/protocol-http": "3.347.0",
+        "@aws-sdk/types": "3.347.0",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -518,15 +551,15 @@
       }
     },
     "node_modules/@aws-sdk/middleware-endpoint": {
-      "version": "3.329.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-endpoint/-/middleware-endpoint-3.329.0.tgz",
-      "integrity": "sha512-hdJRoNdCM0BT4W+rrtee+kfFRgGPGXQDgtbIQlf/FuuuYz2sdef7/SYWr0mxuncnVBW5WkYSPP8h6q07whSKbg==",
+      "version": "3.347.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-endpoint/-/middleware-endpoint-3.347.0.tgz",
+      "integrity": "sha512-unF0c6dMaUL1ffU+37Ugty43DgMnzPWXr/Jup/8GbK5fzzWT5NQq6dj9KHPubMbWeEjQbmczvhv25JuJdK8gNQ==",
       "dev": true,
       "dependencies": {
-        "@aws-sdk/middleware-serde": "3.329.0",
-        "@aws-sdk/types": "3.329.0",
-        "@aws-sdk/url-parser": "3.329.0",
-        "@aws-sdk/util-middleware": "3.329.0",
+        "@aws-sdk/middleware-serde": "3.347.0",
+        "@aws-sdk/types": "3.347.0",
+        "@aws-sdk/url-parser": "3.347.0",
+        "@aws-sdk/util-middleware": "3.347.0",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -534,13 +567,13 @@
       }
     },
     "node_modules/@aws-sdk/middleware-host-header": {
-      "version": "3.329.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.329.0.tgz",
-      "integrity": "sha512-JrHeUdTIpTCfXDo9JpbAbZTS1x4mt63CCytJRq0mpWp+FlP9hjckBcNxWdR/wSKEzP9pDRnTri638BOwWH7O8w==",
+      "version": "3.347.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.347.0.tgz",
+      "integrity": "sha512-kpKmR9OvMlnReqp5sKcJkozbj1wmlblbVSbnQAIkzeQj2xD5dnVR3Nn2ogQKxSmU1Fv7dEroBtrruJ1o3fY38A==",
       "dev": true,
       "dependencies": {
-        "@aws-sdk/protocol-http": "3.329.0",
-        "@aws-sdk/types": "3.329.0",
+        "@aws-sdk/protocol-http": "3.347.0",
+        "@aws-sdk/types": "3.347.0",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -548,12 +581,12 @@
       }
     },
     "node_modules/@aws-sdk/middleware-logger": {
-      "version": "3.329.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.329.0.tgz",
-      "integrity": "sha512-lKeeTXsYC1NiwmxrXsZepcwNXPoQxTNNbeD1qaCELPGK2cJlrGoeAP2YRWzpwO2kNZWrDLaGAPT/EUEhqw+d1w==",
+      "version": "3.347.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.347.0.tgz",
+      "integrity": "sha512-NYC+Id5UCkVn+3P1t/YtmHt75uED06vwaKyxDy0UmB2K66PZLVtwWbLpVWrhbroaw1bvUHYcRyQ9NIfnVcXQjA==",
       "dev": true,
       "dependencies": {
-        "@aws-sdk/types": "3.329.0",
+        "@aws-sdk/types": "3.347.0",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -561,13 +594,13 @@
       }
     },
     "node_modules/@aws-sdk/middleware-recursion-detection": {
-      "version": "3.329.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.329.0.tgz",
-      "integrity": "sha512-0/TYOJwrj1Z8s+Y7thibD23hggBq/K/01NwPk32CwWG/G+1vWozs5DefknEl++w0vuV+39pkY4KHI8m/+wOCpg==",
+      "version": "3.347.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.347.0.tgz",
+      "integrity": "sha512-qfnSvkFKCAMjMHR31NdsT0gv5Sq/ZHTUD4yQsSLpbVQ6iYAS834lrzXt41iyEHt57Y514uG7F/Xfvude3u4icQ==",
       "dev": true,
       "dependencies": {
-        "@aws-sdk/protocol-http": "3.329.0",
-        "@aws-sdk/types": "3.329.0",
+        "@aws-sdk/protocol-http": "3.347.0",
+        "@aws-sdk/types": "3.347.0",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -575,16 +608,16 @@
       }
     },
     "node_modules/@aws-sdk/middleware-retry": {
-      "version": "3.329.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-retry/-/middleware-retry-3.329.0.tgz",
-      "integrity": "sha512-cB3D7GlhHUcHGOlygOYxD9cPhwsTYEAMcohK38An8+RHNp6VQEWezzLFCmHVKUSeCQ+wkjZfPA40jOG0rbjSgQ==",
+      "version": "3.354.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-retry/-/middleware-retry-3.354.0.tgz",
+      "integrity": "sha512-dnG5Nd/mobbhcWCM71DQWI9+f6b6fDSzALXftFIP/8lsXKRcWDSQuYjrnVST2wZzk/QmdF8TnVD0C1xL14K6CQ==",
       "dev": true,
       "dependencies": {
-        "@aws-sdk/protocol-http": "3.329.0",
-        "@aws-sdk/service-error-classification": "3.329.0",
-        "@aws-sdk/types": "3.329.0",
-        "@aws-sdk/util-middleware": "3.329.0",
-        "@aws-sdk/util-retry": "3.329.0",
+        "@aws-sdk/protocol-http": "3.347.0",
+        "@aws-sdk/service-error-classification": "3.347.0",
+        "@aws-sdk/types": "3.347.0",
+        "@aws-sdk/util-middleware": "3.347.0",
+        "@aws-sdk/util-retry": "3.347.0",
         "tslib": "^2.5.0",
         "uuid": "^8.3.2"
       },
@@ -593,13 +626,13 @@
       }
     },
     "node_modules/@aws-sdk/middleware-sdk-sts": {
-      "version": "3.329.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-sts/-/middleware-sdk-sts-3.329.0.tgz",
-      "integrity": "sha512-bqtZuhkH8pANb2Gb4FEM1p27o+BoDBmVhEWm8sWH+APsyOor3jc6eUG2GxkfoO6D5tGNIuyCC/GuvW9XDIe4Kg==",
+      "version": "3.354.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-sts/-/middleware-sdk-sts-3.354.0.tgz",
+      "integrity": "sha512-L6vyAwYrdcOoB4YgCqNJNr+ZZtLHEF2Ym3CTfmFm2srXHqHuRB+mBu0NLV/grz77znIArK1H1ZL/ZaH2I5hclA==",
       "dev": true,
       "dependencies": {
-        "@aws-sdk/middleware-signing": "3.329.0",
-        "@aws-sdk/types": "3.329.0",
+        "@aws-sdk/middleware-signing": "3.354.0",
+        "@aws-sdk/types": "3.347.0",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -607,12 +640,12 @@
       }
     },
     "node_modules/@aws-sdk/middleware-serde": {
-      "version": "3.329.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-serde/-/middleware-serde-3.329.0.tgz",
-      "integrity": "sha512-tvM9NdPuRPCozPjTGNOeYZeLlyx3BcEyajrkRorCRf1YzG/mXdB6I1stote7i4q1doFtYTz0sYL8bqW3LUPn9A==",
+      "version": "3.347.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-serde/-/middleware-serde-3.347.0.tgz",
+      "integrity": "sha512-x5Foi7jRbVJXDu9bHfyCbhYDH5pKK+31MmsSJ3k8rY8keXLBxm2XEEg/AIoV9/TUF9EeVvZ7F1/RmMpJnWQsEg==",
       "dev": true,
       "dependencies": {
-        "@aws-sdk/types": "3.329.0",
+        "@aws-sdk/types": "3.347.0",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -620,16 +653,16 @@
       }
     },
     "node_modules/@aws-sdk/middleware-signing": {
-      "version": "3.329.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-signing/-/middleware-signing-3.329.0.tgz",
-      "integrity": "sha512-bL1nI+EUcF5B1ipwDXxiKL+Uw02Mbt/TNX54PbzunBGZIyO6DZG/H+M3U296bYbvPlwlZhp26O830g6K7VEWsA==",
+      "version": "3.354.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-signing/-/middleware-signing-3.354.0.tgz",
+      "integrity": "sha512-Dd+vIhJL0VqqKWqlTKlKC5jkCaEIk73ZEXNfv44XbsI25a0vXbatHp1M8jB/cgkJC/Mri1TX9dmckP/C0FDEwA==",
       "dev": true,
       "dependencies": {
-        "@aws-sdk/property-provider": "3.329.0",
-        "@aws-sdk/protocol-http": "3.329.0",
-        "@aws-sdk/signature-v4": "3.329.0",
-        "@aws-sdk/types": "3.329.0",
-        "@aws-sdk/util-middleware": "3.329.0",
+        "@aws-sdk/property-provider": "3.353.0",
+        "@aws-sdk/protocol-http": "3.347.0",
+        "@aws-sdk/signature-v4": "3.354.0",
+        "@aws-sdk/types": "3.347.0",
+        "@aws-sdk/util-middleware": "3.347.0",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -637,9 +670,9 @@
       }
     },
     "node_modules/@aws-sdk/middleware-stack": {
-      "version": "3.329.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-stack/-/middleware-stack-3.329.0.tgz",
-      "integrity": "sha512-2huFLhJ45td2nuiIOjpc9JKJbFNn5CYmw9U8YDITTcydpteRN62CzCpeqroDvF89VOLWxh0ZFtuLCGUr7liSWQ==",
+      "version": "3.347.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-stack/-/middleware-stack-3.347.0.tgz",
+      "integrity": "sha512-Izidg4rqtYMcKuvn2UzgEpPLSmyd8ub9+LQ2oIzG3mpIzCBITq7wp40jN1iNkMg+X6KEnX9vdMJIYZsPYMCYuQ==",
       "dev": true,
       "dependencies": {
         "tslib": "^2.5.0"
@@ -649,14 +682,14 @@
       }
     },
     "node_modules/@aws-sdk/middleware-user-agent": {
-      "version": "3.329.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.329.0.tgz",
-      "integrity": "sha512-cA0AQ9dSZKVBgVNgzeJ2hzUYTG8iY/bLES+sOBK1A7XBl/VqwDQ8OelnoKj/ldL+dJfo9P85kdfYTQsjE4OUlQ==",
+      "version": "3.352.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.352.0.tgz",
+      "integrity": "sha512-QGqblMTsVDqeomy22KPm9LUW8PHZXBA2Hjk9Hcw8U1uFS8IKYJrewInG3ae2+9FAcTyug4LFWDf8CRr9YH2B3Q==",
       "dev": true,
       "dependencies": {
-        "@aws-sdk/protocol-http": "3.329.0",
-        "@aws-sdk/types": "3.329.0",
-        "@aws-sdk/util-endpoints": "3.329.0",
+        "@aws-sdk/protocol-http": "3.347.0",
+        "@aws-sdk/types": "3.347.0",
+        "@aws-sdk/util-endpoints": "3.352.0",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -664,14 +697,14 @@
       }
     },
     "node_modules/@aws-sdk/node-config-provider": {
-      "version": "3.329.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/node-config-provider/-/node-config-provider-3.329.0.tgz",
-      "integrity": "sha512-hg9rGNlkzh8aeR/sQbijrkFx2BIO53j4Z6qDxPNWwSGpl05jri1VHxHx2HZMwgbY6Zy/DSguETN/BL8vdFqyLg==",
+      "version": "3.354.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/node-config-provider/-/node-config-provider-3.354.0.tgz",
+      "integrity": "sha512-pF1ZGWWvmwbrloNHYF3EDqCb9hq5wfZwDqAwAPhWkYnUYKkR7E7MZVuTwUDU48io8k6Z5pM52l/54w8e8aedTw==",
       "dev": true,
       "dependencies": {
-        "@aws-sdk/property-provider": "3.329.0",
-        "@aws-sdk/shared-ini-file-loader": "3.329.0",
-        "@aws-sdk/types": "3.329.0",
+        "@aws-sdk/property-provider": "3.353.0",
+        "@aws-sdk/shared-ini-file-loader": "3.354.0",
+        "@aws-sdk/types": "3.347.0",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -679,15 +712,15 @@
       }
     },
     "node_modules/@aws-sdk/node-http-handler": {
-      "version": "3.329.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/node-http-handler/-/node-http-handler-3.329.0.tgz",
-      "integrity": "sha512-OrjaHjU2ZTPfoHa5DruRvTIbeHH/cc0wvh4ml+FwDpWaPaBpOhLiluhZ3anqX1l5QjrXNiQnL8FxSM5OV/zVCA==",
+      "version": "3.350.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/node-http-handler/-/node-http-handler-3.350.0.tgz",
+      "integrity": "sha512-oD96GAlmpzYilCdC8wwyURM5lNfNHZCjm/kxBkQulHKa2kRbIrnD9GfDqdCkWA5cTpjh1NzGLT4D6e6UFDjt9w==",
       "dev": true,
       "dependencies": {
-        "@aws-sdk/abort-controller": "3.329.0",
-        "@aws-sdk/protocol-http": "3.329.0",
-        "@aws-sdk/querystring-builder": "3.329.0",
-        "@aws-sdk/types": "3.329.0",
+        "@aws-sdk/abort-controller": "3.347.0",
+        "@aws-sdk/protocol-http": "3.347.0",
+        "@aws-sdk/querystring-builder": "3.347.0",
+        "@aws-sdk/types": "3.347.0",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -695,12 +728,12 @@
       }
     },
     "node_modules/@aws-sdk/property-provider": {
-      "version": "3.329.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/property-provider/-/property-provider-3.329.0.tgz",
-      "integrity": "sha512-1cHLTV6yyMGaMSWWDW/p4vTkJ1cc5BOEO+A0eHuAcoSOk+LDe9IKhUG3/ZOvvYKQYcqIj5jjGSni/noXNCl/qw==",
+      "version": "3.353.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/property-provider/-/property-provider-3.353.0.tgz",
+      "integrity": "sha512-Iu6J59hncaew7eBKroTcLjZ8cgrom0IWyZZ09rsow3rZDHVtw7LQSrUyuqsSbKGY9eRtL7Wa6ZtYHnXFiAE2kg==",
       "dev": true,
       "dependencies": {
-        "@aws-sdk/types": "3.329.0",
+        "@aws-sdk/types": "3.347.0",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -708,12 +741,12 @@
       }
     },
     "node_modules/@aws-sdk/protocol-http": {
-      "version": "3.329.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.329.0.tgz",
-      "integrity": "sha512-0rLEHY6QTHTUUcVxzGbPUSmCKlXWplxT/fcYRh0bcc5MBK4naKfcQft1O6Ajp8uqs/9YPZ7XCVCn90pDeJfeaw==",
+      "version": "3.347.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.347.0.tgz",
+      "integrity": "sha512-2YdBhc02Wvy03YjhGwUxF0UQgrPWEy8Iq75pfS42N+/0B/+eWX1aQgfjFxIpLg7YSjT5eKtYOQGlYd4MFTgj9g==",
       "dev": true,
       "dependencies": {
-        "@aws-sdk/types": "3.329.0",
+        "@aws-sdk/types": "3.347.0",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -721,12 +754,12 @@
       }
     },
     "node_modules/@aws-sdk/querystring-builder": {
-      "version": "3.329.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-builder/-/querystring-builder-3.329.0.tgz",
-      "integrity": "sha512-UWgMKkS5trliaDJG4nPv3onu8Y0aBuwRo7RdIgggguOiU8pU6pq1I113nH2FBNWy+Me1bwf+bcviJh0pCo6bEg==",
+      "version": "3.347.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-builder/-/querystring-builder-3.347.0.tgz",
+      "integrity": "sha512-phtKTe6FXoV02MoPkIVV6owXI8Mwr5IBN3bPoxhcPvJG2AjEmnetSIrhb8kwc4oNhlwfZwH6Jo5ARW/VEWbZtg==",
       "dev": true,
       "dependencies": {
-        "@aws-sdk/types": "3.329.0",
+        "@aws-sdk/types": "3.347.0",
         "@aws-sdk/util-uri-escape": "3.310.0",
         "tslib": "^2.5.0"
       },
@@ -735,12 +768,12 @@
       }
     },
     "node_modules/@aws-sdk/querystring-parser": {
-      "version": "3.329.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-parser/-/querystring-parser-3.329.0.tgz",
-      "integrity": "sha512-9mkK+FB7snJ2G7H3CqtprDwYIRhzm6jEezffCwUWrC+lbqHBbErbhE9IeU/MKxILmf0RbC2riXEY1MHGspjRrQ==",
+      "version": "3.347.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-parser/-/querystring-parser-3.347.0.tgz",
+      "integrity": "sha512-5VXOhfZz78T2W7SuXf2avfjKglx1VZgZgp9Zfhrt/Rq+MTu2D+PZc5zmJHhYigD7x83jLSLogpuInQpFMA9LgA==",
       "dev": true,
       "dependencies": {
-        "@aws-sdk/types": "3.329.0",
+        "@aws-sdk/types": "3.347.0",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -748,21 +781,21 @@
       }
     },
     "node_modules/@aws-sdk/service-error-classification": {
-      "version": "3.329.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/service-error-classification/-/service-error-classification-3.329.0.tgz",
-      "integrity": "sha512-TSNr0flOcCLe71aPp7MjblKNGsmxpTU4xR5772MDX9Cz9GUTNZCPFtvrcqd+wzEPP/AC7XwNXe8KjoXooZImUQ==",
+      "version": "3.347.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/service-error-classification/-/service-error-classification-3.347.0.tgz",
+      "integrity": "sha512-xZ3MqSY81Oy2gh5g0fCtooAbahqh9VhsF8vcKjVX8+XPbGC8y+kej82+MsMg4gYL8gRFB9u4hgYbNgIS6JTAvg==",
       "dev": true,
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/shared-ini-file-loader": {
-      "version": "3.329.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/shared-ini-file-loader/-/shared-ini-file-loader-3.329.0.tgz",
-      "integrity": "sha512-e0hyd75fbjMd4aCoRwpP2/HR+0oScwogErVArIkq3F42c/hyNCQP3sph4JImuXIjuo6HNnpKpf20CEPPhNna8A==",
+      "version": "3.354.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/shared-ini-file-loader/-/shared-ini-file-loader-3.354.0.tgz",
+      "integrity": "sha512-UL9loGEsdzpHBu/PtlwUvkl/yRdmWXkySp22jUaeeRtBhiGAnyeYhxJLIt+u+UkX7Mwz+810SaZJqA9ptOXNAg==",
       "dev": true,
       "dependencies": {
-        "@aws-sdk/types": "3.329.0",
+        "@aws-sdk/types": "3.347.0",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -770,15 +803,16 @@
       }
     },
     "node_modules/@aws-sdk/signature-v4": {
-      "version": "3.329.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4/-/signature-v4-3.329.0.tgz",
-      "integrity": "sha512-9EnLoyOD5nFtCRAp+QRllDgQASCfY7jLHVhwht7jzwE80wE65Z9Ym5Z/mwTd4IyTz/xXfCvcE2VwClsBt0Ybdw==",
+      "version": "3.354.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4/-/signature-v4-3.354.0.tgz",
+      "integrity": "sha512-bDp43P5NkwwznpZqmsr78DuyqNcjtS4mriuajb8XPhFNo8DrMXUrdrKJ+5aNABW7YG8uK8PSKBpq88ado692/w==",
       "dev": true,
       "dependencies": {
+        "@aws-sdk/eventstream-codec": "3.347.0",
         "@aws-sdk/is-array-buffer": "3.310.0",
-        "@aws-sdk/types": "3.329.0",
+        "@aws-sdk/types": "3.347.0",
         "@aws-sdk/util-hex-encoding": "3.310.0",
-        "@aws-sdk/util-middleware": "3.329.0",
+        "@aws-sdk/util-middleware": "3.347.0",
         "@aws-sdk/util-uri-escape": "3.310.0",
         "@aws-sdk/util-utf8": "3.310.0",
         "tslib": "^2.5.0"
@@ -788,13 +822,13 @@
       }
     },
     "node_modules/@aws-sdk/smithy-client": {
-      "version": "3.329.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/smithy-client/-/smithy-client-3.329.0.tgz",
-      "integrity": "sha512-7E0fGpBKxwFqHHAOqNbgNsHSEmCZLuvmU9yvG9DXKVzrS4P48O/PfOro123WpcFZs3STyOVgH8wjUPftHAVKmg==",
+      "version": "3.347.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/smithy-client/-/smithy-client-3.347.0.tgz",
+      "integrity": "sha512-PaGTDsJLGK0sTjA6YdYQzILRlPRN3uVFyqeBUkfltXssvUzkm8z2t1lz2H4VyJLAhwnG5ZuZTNEV/2mcWrU7JQ==",
       "dev": true,
       "dependencies": {
-        "@aws-sdk/middleware-stack": "3.329.0",
-        "@aws-sdk/types": "3.329.0",
+        "@aws-sdk/middleware-stack": "3.347.0",
+        "@aws-sdk/types": "3.347.0",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -802,15 +836,15 @@
       }
     },
     "node_modules/@aws-sdk/token-providers": {
-      "version": "3.329.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.329.0.tgz",
-      "integrity": "sha512-r53sH9OC8FjecIRavTfqvb2pLH3g1uVDFUuArKyzqY8Qypq/8oUc6LwsCWAwFQwHnmxsenKK/0ESHgNHfOW/+A==",
+      "version": "3.354.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.354.0.tgz",
+      "integrity": "sha512-KcijiySy0oIyafKQagcwgu0fo35mK+2K8pwxRU1WfXqe80Gn1qGceeWcG4iW+t/rUaxa/LVo857N0LcagxCrZA==",
       "dev": true,
       "dependencies": {
-        "@aws-sdk/client-sso-oidc": "3.329.0",
-        "@aws-sdk/property-provider": "3.329.0",
-        "@aws-sdk/shared-ini-file-loader": "3.329.0",
-        "@aws-sdk/types": "3.329.0",
+        "@aws-sdk/client-sso-oidc": "3.354.0",
+        "@aws-sdk/property-provider": "3.353.0",
+        "@aws-sdk/shared-ini-file-loader": "3.354.0",
+        "@aws-sdk/types": "3.347.0",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -818,9 +852,9 @@
       }
     },
     "node_modules/@aws-sdk/types": {
-      "version": "3.329.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.329.0.tgz",
-      "integrity": "sha512-wFBW4yciDfzQBSFmWNaEvHShnSGLMxSu9Lls6EUf6xDMavxSB36bsrVRX6CyAo/W0NeIIyEOW1LclGPgJV1okg==",
+      "version": "3.347.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.347.0.tgz",
+      "integrity": "sha512-GkCMy79mdjU9OTIe5KT58fI/6uqdf8UmMdWqVHmFJ+UpEzOci7L/uw4sOXWo7xpPzLs6cJ7s5ouGZW4GRPmHFA==",
       "dev": true,
       "dependencies": {
         "tslib": "^2.5.0"
@@ -830,13 +864,13 @@
       }
     },
     "node_modules/@aws-sdk/url-parser": {
-      "version": "3.329.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/url-parser/-/url-parser-3.329.0.tgz",
-      "integrity": "sha512-/VcfL7vNJKJGSjYYHVQF3bYCDFs4fSzB7j5qeVDwRdWr870gE7O1Dar+sLWBRKFF3AX+4VzplqzUfpu9t44JVA==",
+      "version": "3.347.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/url-parser/-/url-parser-3.347.0.tgz",
+      "integrity": "sha512-lhrnVjxdV7hl+yCnJfDZOaVLSqKjxN20MIOiijRiqaWGLGEAiSqBreMhL89X1WKCifxAs4zZf9YB9SbdziRpAA==",
       "dev": true,
       "dependencies": {
-        "@aws-sdk/querystring-parser": "3.329.0",
-        "@aws-sdk/types": "3.329.0",
+        "@aws-sdk/querystring-parser": "3.347.0",
+        "@aws-sdk/types": "3.347.0",
         "tslib": "^2.5.0"
       }
     },
@@ -900,13 +934,13 @@
       }
     },
     "node_modules/@aws-sdk/util-defaults-mode-browser": {
-      "version": "3.329.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-browser/-/util-defaults-mode-browser-3.329.0.tgz",
-      "integrity": "sha512-2iSiy/pzX3OXMhtSxtAzOiEFr3viQEFnYOTeZuiheuyS+cea2L79F6SlZ1110b/nOIU/UOrxxtz83HVad8YFMQ==",
+      "version": "3.353.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-browser/-/util-defaults-mode-browser-3.353.0.tgz",
+      "integrity": "sha512-ushvOQKJIH7S6E//xMDPyf2/Bbu0K2A0GJRB88qQV6VKRBo4PEbeHTb6BbzPhYVX0IbY3uR/X7+Xwk4FeEkMWg==",
       "dev": true,
       "dependencies": {
-        "@aws-sdk/property-provider": "3.329.0",
-        "@aws-sdk/types": "3.329.0",
+        "@aws-sdk/property-provider": "3.353.0",
+        "@aws-sdk/types": "3.347.0",
         "bowser": "^2.11.0",
         "tslib": "^2.5.0"
       },
@@ -915,16 +949,16 @@
       }
     },
     "node_modules/@aws-sdk/util-defaults-mode-node": {
-      "version": "3.329.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-node/-/util-defaults-mode-node-3.329.0.tgz",
-      "integrity": "sha512-7A6C7YKjkZtmKtH29isYEtOCbhd7IcXPP8lftN8WAWlLOiZE4gV7PHveagUj7QserJzgRKGwwTQbBj53n18HYg==",
+      "version": "3.354.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-node/-/util-defaults-mode-node-3.354.0.tgz",
+      "integrity": "sha512-CaaRVBdOYX4wZadj+CDUxpO+4RjyYJcSv71A60jV6CZ/ya1+oYfmPbG5QZ4AlV6crdev2B+aUoR2LPIYqn/GnQ==",
       "dev": true,
       "dependencies": {
-        "@aws-sdk/config-resolver": "3.329.0",
-        "@aws-sdk/credential-provider-imds": "3.329.0",
-        "@aws-sdk/node-config-provider": "3.329.0",
-        "@aws-sdk/property-provider": "3.329.0",
-        "@aws-sdk/types": "3.329.0",
+        "@aws-sdk/config-resolver": "3.354.0",
+        "@aws-sdk/credential-provider-imds": "3.354.0",
+        "@aws-sdk/node-config-provider": "3.354.0",
+        "@aws-sdk/property-provider": "3.353.0",
+        "@aws-sdk/types": "3.347.0",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -932,12 +966,12 @@
       }
     },
     "node_modules/@aws-sdk/util-endpoints": {
-      "version": "3.329.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.329.0.tgz",
-      "integrity": "sha512-AlBHc4c+dj5pNMBoPFLGpB/+4Fe9nxe6eUf8T9Wu5QcTK+u6L8aiH1oGKv/1TxqwoPvqtrjb3HMBafUsB5Mw/g==",
+      "version": "3.352.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.352.0.tgz",
+      "integrity": "sha512-PjWMPdoIUWfBPgAWLyOrWFbdSS/3DJtc0OmFb/JrE8C8rKFYl+VGW5f1p0cVdRWiDR0xCGr0s67p8itAakVqjw==",
       "dev": true,
       "dependencies": {
-        "@aws-sdk/types": "3.329.0",
+        "@aws-sdk/types": "3.347.0",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -969,9 +1003,9 @@
       }
     },
     "node_modules/@aws-sdk/util-middleware": {
-      "version": "3.329.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-middleware/-/util-middleware-3.329.0.tgz",
-      "integrity": "sha512-RhBOBaxzkTUghi4MSqr8S5qeeBCjgJ0XPJ6jIYkVkj1saCmqkuZCgl3zFaYdyhdxxPV6nflkFer+1HUoqT+Fqw==",
+      "version": "3.347.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-middleware/-/util-middleware-3.347.0.tgz",
+      "integrity": "sha512-8owqUA3ePufeYTUvlzdJ7Z0miLorTwx+rNol5lourGQZ9JXsVMo23+yGA7nOlFuXSGkoKpMOtn6S0BT2bcfeiw==",
       "dev": true,
       "dependencies": {
         "tslib": "^2.5.0"
@@ -981,12 +1015,12 @@
       }
     },
     "node_modules/@aws-sdk/util-retry": {
-      "version": "3.329.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-retry/-/util-retry-3.329.0.tgz",
-      "integrity": "sha512-+3VQ9HZLinysnmryUs9Xjt1YVh4TYYHLt30ilu4iUnIHFQoamdzIbRCWseSVFPCxGroen9M9qmAleAsytHEKuA==",
+      "version": "3.347.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-retry/-/util-retry-3.347.0.tgz",
+      "integrity": "sha512-NxnQA0/FHFxriQAeEgBonA43Q9/VPFQa8cfJDuT2A1YZruMasgjcltoZszi1dvoIRWSZsFTW42eY2gdOd0nffQ==",
       "dev": true,
       "dependencies": {
-        "@aws-sdk/service-error-classification": "3.329.0",
+        "@aws-sdk/service-error-classification": "3.347.0",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -1006,24 +1040,24 @@
       }
     },
     "node_modules/@aws-sdk/util-user-agent-browser": {
-      "version": "3.329.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.329.0.tgz",
-      "integrity": "sha512-8hLSmMCl8aw2++0Zuba8ELq8FkK6/VNyx470St201IpMn2GMbQMDl/rLolRKiTgji6wc+T3pOTidkJkz8/cIXA==",
+      "version": "3.347.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.347.0.tgz",
+      "integrity": "sha512-ydxtsKVtQefgbk1Dku1q7pMkjDYThauG9/8mQkZUAVik55OUZw71Zzr3XO8J8RKvQG8lmhPXuAQ0FKAyycc0RA==",
       "dev": true,
       "dependencies": {
-        "@aws-sdk/types": "3.329.0",
+        "@aws-sdk/types": "3.347.0",
         "bowser": "^2.11.0",
         "tslib": "^2.5.0"
       }
     },
     "node_modules/@aws-sdk/util-user-agent-node": {
-      "version": "3.329.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.329.0.tgz",
-      "integrity": "sha512-C50Zaeodc0+psEP+L4WpElrH8epuLWJPVN4hDOTORcM0cSoU2o025Ost9mbcU7UdoHNxF9vitLnzORGN9SHolg==",
+      "version": "3.354.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.354.0.tgz",
+      "integrity": "sha512-2xkblZS3PGxxh//0lgCwJw2gvh9ZBcI9H9xv05YP7hcwlz9BmkAlbei2i6Uew6agJMLO4unfgWoBTpzp3WLaKg==",
       "dev": true,
       "dependencies": {
-        "@aws-sdk/node-config-provider": "3.329.0",
-        "@aws-sdk/types": "3.329.0",
+        "@aws-sdk/node-config-provider": "3.354.0",
+        "@aws-sdk/types": "3.347.0",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -2249,6 +2283,31 @@
       "dev": true,
       "dependencies": {
         "@sinonjs/commons": "^1.7.0"
+      }
+    },
+    "node_modules/@smithy/protocol-http": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-1.0.1.tgz",
+      "integrity": "sha512-9OrEn0WfOVtBNYJUjUAn9AOiJ4lzERCJJ/JeZs8E6yajTGxBaFRxUnNBHiNqoDJVg076hY36UmEnPx7xXrvUSg==",
+      "dev": true,
+      "dependencies": {
+        "@smithy/types": "^1.0.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/types": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-1.0.0.tgz",
+      "integrity": "sha512-kc1m5wPBHQCTixwuaOh9vnak/iJm21DrSf9UK6yDE5S3mQQ4u11pqAUiKWnlrZnYkeLfAI9UEHj9OaMT1v5Umg==",
+      "dev": true,
+      "dependencies": {
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@tootallnate/once": {
@@ -3922,19 +3981,25 @@
       "dev": true
     },
     "node_modules/fast-xml-parser": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.1.2.tgz",
-      "integrity": "sha512-CDYeykkle1LiA/uqQyNwYpFbyF6Axec6YapmpUP+/RHWIoR1zKjocdvNaTsxCxZzQ6v9MLXaSYm9Qq0thv0DHg==",
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.2.4.tgz",
+      "integrity": "sha512-fbfMDvgBNIdDJLdLOwacjFAPYt67tr31H9ZhWSm45CDAxvd0I6WTlSOUo7K2P/K5sA5JgMKG64PI3DMcaFdWpQ==",
       "dev": true,
+      "funding": [
+        {
+          "type": "paypal",
+          "url": "https://paypal.me/naturalintelligence"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
       "dependencies": {
         "strnum": "^1.0.5"
       },
       "bin": {
         "fxparser": "src/cli/cli.js"
-      },
-      "funding": {
-        "type": "paypal",
-        "url": "https://paypal.me/naturalintelligence"
       }
     },
     "node_modules/fastq": {

--- a/src-js/package-lock.json
+++ b/src-js/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "amazon-textract-response-parser",
-  "version": "0.2.1",
+  "version": "0.2.2-alpha.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "amazon-textract-response-parser",
-      "version": "0.2.1",
+      "version": "0.2.2-alpha.1",
       "license": "Apache-2.0",
       "devDependencies": {
         "@aws-sdk/client-textract": "^3.43.0",

--- a/src-js/package.json
+++ b/src-js/package.json
@@ -1,16 +1,16 @@
 {
   "name": "amazon-textract-response-parser",
-  "version": "0.2.1",
+  "version": "0.2.2-alpha.1",
   "description": "Parse API responses from Amazon Textract with higher-level helpers",
   "keywords": [
     "aws",
     "amazon-textract",
     "textract"
   ],
-  "browser": "dist/browser/trp.min.js",
   "main": "dist/cjs/index.js",
   "module": "dist/es/index.js",
   "types": "dist/types/index.d.ts",
+  "jsdelivr": "dist/browser/trp.min.js",
   "unpkg": "dist/browser/trp.min.js",
   "directories": {
     "lib": "lib"

--- a/src-js/package.json
+++ b/src-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "amazon-textract-response-parser",
-  "version": "0.2.2-alpha.1",
+  "version": "0.2.2",
   "description": "Parse API responses from Amazon Textract with higher-level helpers",
   "keywords": [
     "aws",

--- a/src-js/rollup.config.js
+++ b/src-js/rollup.config.js
@@ -3,15 +3,12 @@ import resolve from "@rollup/plugin-node-resolve";
 import typescript from "@rollup/plugin-typescript";
 import { terser } from "rollup-plugin-terser";
 
-// Local Dependencies:
-import pkg from "./package.json";
-
 export default [
   {
     input: "src/index.ts",
     output: {
       name: "trp",
-      file: pkg.browser,
+      file: "dist/browser/trp.min.js",
       format: "iife",
       sourcemap: true,
       plugins: [


### PR DESCRIPTION
**Issue #, if available:** #139

**Description of changes:**

- Remove the `browser` field from package.json (which previously pointed to the IIFE build of the library), and replace it with a `jsdelivr` field pointing to same location.

While IIFE is appropriate for direct-to-browser use with CDNs like jsDelivr and UNPKG, front end frameworks like webpack also refer to this `browser` field - but they should use standard CommonJS build instead to import the library correctly.

**Testing done:**

This change can be conveniently tested in user code via published NPM version [v0.2.2-alpha.1](https://www.npmjs.com/package/amazon-textract-response-parser/v/0.2.2-alpha.1).

From my side, verified that:

- No changes to unit/integration tests passing
- This resolves broken imports on a variation of the [React+Next.js sample app](https://github.com/kieferenriquez/qidp/blob/main/src/pages/payables/index.tsx) provided for #139
- A basic NodeJS+TypeScript server side app still consumes the library as expected
- The sample SageMaker Ground Truth [bounding boxes + Textract reconciliation annotation template](https://github.com/aws-samples/amazon-textract-transformer-pipeline/blob/main/notebooks/annotation/ocr-bbox-and-validation.liquid.tpl.html) in Amazon-Textract-Transformer-Pipeline (which uses the IIFE build via CDN) still works via either UNPKG or jsDelivr.
- The sample A2I [review template](https://github.com/aws-samples/amazon-textract-transformer-pipeline/tree/main/notebooks/review#readme) in Amazon-Textract-Transformer-Pipeline (which references the IIFE build but also the TypeScript annotations) still builds and runs okay.

**Next steps:**

Ideally we can get fix confirmation from the issue author, then publish mainline `0.2.2` release, rebase the fix branch, and merge.

<br/>

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
