### PR TITLE
TRP.js v0.3.1 release draft

### DIFF
--- a/src-js/CHANGELOG.md
+++ b/src-js/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## In development (targeting 0.3.1)
 ### Fixed
 - Suppress "content may be truncated" warnings when API `NextToken` is present but `null` ([#154](https://github.com/aws-samples/amazon-textract-response-parser/issues/154))
+- Fix typed `TABLE_FOOTER` and `TABLE_SECTION_HEADER` EntityType values to match the [API doc](https://docs.aws.amazon.com/textract/latest/dg/API_Block.html) ([#158](https://github.com/aws-samples/amazon-textract-response-parser/issues/158))
 
 ## 0.3.0 (2023-07-31)
 ### Added

--- a/src-js/CHANGELOG.md
+++ b/src-js/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## In development (targeting 0.3.1)
+### Fixed
+- Suppress "content may be truncated" warnings when API `NextToken` is present but `null` ([#154](https://github.com/aws-samples/amazon-textract-response-parser/issues/154))
+
 ## 0.3.0 (2023-07-31)
 ### Added
 - **(BREAKING)** `ignoreMerged` and `repeatMultiRowCells` options on `Table` methods are now wrapped into `opts` objects for better future extensibility and clearer user code.

--- a/src-js/CHANGELOG.md
+++ b/src-js/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## In development (targeting 0.3.1)
+## 0.3.1 (2023-08-28)
 ### Fixed
 - Suppress "content may be truncated" warnings when API `NextToken` is present but `null` ([#154](https://github.com/aws-samples/amazon-textract-response-parser/issues/154))
 - Fix typed `TABLE_FOOTER` and `TABLE_SECTION_HEADER` EntityType values to match the [API doc](https://docs.aws.amazon.com/textract/latest/dg/API_Block.html) ([#158](https://github.com/aws-samples/amazon-textract-response-parser/issues/158))

--- a/src-js/package-lock.json
+++ b/src-js/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "amazon-textract-response-parser",
-  "version": "0.3.1-dev",
+  "version": "0.3.1-alpha.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "amazon-textract-response-parser",
-      "version": "0.3.1-dev",
+      "version": "0.3.1-alpha.2",
       "license": "Apache-2.0",
       "devDependencies": {
         "@aws-sdk/client-textract": "^3.43.0",

--- a/src-js/package-lock.json
+++ b/src-js/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "amazon-textract-response-parser",
-  "version": "0.3.0",
+  "version": "0.3.1-alpha.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "amazon-textract-response-parser",
-      "version": "0.3.0",
+      "version": "0.3.1-alpha.1",
       "license": "Apache-2.0",
       "devDependencies": {
         "@aws-sdk/client-textract": "^3.43.0",

--- a/src-js/package-lock.json
+++ b/src-js/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "amazon-textract-response-parser",
-  "version": "0.3.1-alpha.2",
+  "version": "0.3.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "amazon-textract-response-parser",
-      "version": "0.3.1-alpha.2",
+      "version": "0.3.1",
       "license": "Apache-2.0",
       "devDependencies": {
         "@aws-sdk/client-textract": "^3.43.0",

--- a/src-js/package-lock.json
+++ b/src-js/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "amazon-textract-response-parser",
-  "version": "0.3.1-alpha.1",
+  "version": "0.3.1-dev",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "amazon-textract-response-parser",
-      "version": "0.3.1-alpha.1",
+      "version": "0.3.1-dev",
       "license": "Apache-2.0",
       "devDependencies": {
         "@aws-sdk/client-textract": "^3.43.0",

--- a/src-js/package.json
+++ b/src-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "amazon-textract-response-parser",
-  "version": "0.3.1-alpha.2",
+  "version": "0.3.1",
   "description": "Parse API responses from Amazon Textract with higher-level helpers",
   "keywords": [
     "aws",
@@ -34,6 +34,7 @@
     "test:unit": "jest --coverage --testPathPattern=test/unit"
   },
   "repository": {
+    "directory": "src-js",
     "type": "git",
     "url": "git+https://github.com/aws-samples/amazon-textract-response-parser.git"
   },

--- a/src-js/package.json
+++ b/src-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "amazon-textract-response-parser",
-  "version": "0.3.0",
+  "version": "0.3.1-alpha.1",
   "description": "Parse API responses from Amazon Textract with higher-level helpers",
   "keywords": [
     "aws",

--- a/src-js/package.json
+++ b/src-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "amazon-textract-response-parser",
-  "version": "0.3.1-dev",
+  "version": "0.3.1-alpha.2",
   "description": "Parse API responses from Amazon Textract with higher-level helpers",
   "keywords": [
     "aws",

--- a/src-js/package.json
+++ b/src-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "amazon-textract-response-parser",
-  "version": "0.3.1-alpha.1",
+  "version": "0.3.1-dev",
   "description": "Parse API responses from Amazon Textract with higher-level helpers",
   "keywords": [
     "aws",

--- a/src-js/src/api-models/document.ts
+++ b/src-js/src/api-models/document.ts
@@ -118,8 +118,8 @@ export interface ApiTableBlock {
 
 export const enum ApiTableCellEntityType {
   Title = "TABLE_TITLE",
-  Footer = "FOOTER",
-  SectionTitle = "SECTION_TITLE",
+  Footer = "TABLE_FOOTER",
+  SectionTitle = "TABLE_SECTION_TITLE",
   ColumnHeader = "COLUMN_HEADER",
   Summary = "TABLE_SUMMARY",
 }

--- a/src-js/src/api-models/response.ts
+++ b/src-js/src/api-models/response.ts
@@ -60,30 +60,34 @@ export interface ApiAsyncJobOuputInProgress {
   ];
 }
 
+interface ApiAsyncJobOutputStatus {
+  JobStatus: "IN_PROGRESS" | "SUCCEEDED" | "FAILED" | "PARTIAL_SUCCESS";
+  /**
+   * When present, a continuation token to fetch the next section of the response
+   *
+   * In some cases this field can be present but set to null, as raised in
+   * https://github.com/aws-samples/amazon-textract-response-parser/issues/154
+   */
+  NextToken?: string | null;
+  StatusMessage?: string;
+  Warnings?: ApiResultWarning[];
+}
+
 export interface ApiResultWarning {
   ErrorCode: string;
   Pages: number[];
 }
 
-export interface ApiAsyncJobOuputSucceded extends ApiResponseWithContent {
+export interface ApiAsyncJobOuputSucceded extends ApiResponseWithContent, ApiAsyncJobOutputStatus {
   JobStatus: "SUCCEEDED";
-  NextToken?: string;
-  StatusMessage?: string;
-  Warnings?: ApiResultWarning[];
 }
 
-export interface ApiAsyncJobOutputPartialSuccess extends ApiResponseWithContent {
+export interface ApiAsyncJobOutputPartialSuccess extends ApiResponseWithContent, ApiAsyncJobOutputStatus {
   JobStatus: "PARTIAL_SUCCESS";
-  NextToken?: string;
-  StatusMessage?: string;
-  Warnings?: ApiResultWarning[];
 }
 
-export interface ApiAsyncJobOutputFailed {
+export interface ApiAsyncJobOutputFailed extends ApiAsyncJobOutputStatus {
   JobStatus: "FAILED";
-  NextToken?: string;
-  StatusMessage?: string;
-  Warnings?: ApiResultWarning[];
 }
 
 export type ApiAsyncDocumentAnalysis =

--- a/src-js/src/document.ts
+++ b/src-js/src/document.ts
@@ -881,7 +881,7 @@ export class TextractDocument
     }
     super(dict);
 
-    if ("NextToken" in this._dict) {
+    if ("NextToken" in this._dict && this._dict.NextToken) {
       console.warn(`Provided Textract JSON contains a NextToken: Content may be truncated!`);
     }
 
@@ -1011,12 +1011,16 @@ export class TextractDocument
     const statusMessageFields = jobStatusMessage ? { StatusMessage: jobStatusMessage } : {};
     const warningFields = warnings ? { ArfBarf: warnings } : {};
 
+    const lastItem = textractResultArray[textractResultArray.length - 1];
+    const nextTokenFields = "NextToken" in lastItem ? { NextToken: lastItem.NextToken } : {};
+
     return {
       ...content,
       ...modelVersionFields,
       ...jobStatusFields,
       ...statusMessageFields,
       ...warningFields,
+      ...nextTokenFields,
     };
   }
 


### PR DESCRIPTION
**Issue #, if available:** #154, #158

**Description of changes:**

- (Bugfix) Suppress unnecessary "content may be truncated" warnings when Textract API `NextToken` is present but `null`, and enable proper warning when `NextToken` is present for multi-page constructor `TextractDocument([resp1, resp2, ...])` 
- (Bugfix) Fix `ApiTableCellEntityType` enumerations of `TABLE_FOOTER` and `TABLE_SECTION_TITLE` values

**Testing:**

- Unit tests expanded to cover fixed cases
- Test build available on NPM at [v0.3.1-alpha.2](https://www.npmjs.com/package/amazon-textract-response-parser/v/0.3.1-alpha.2) - feedback appreciated!

<br/>

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
