### PR TITLE
fix(python): fix get_blocks_by_type for pages without relationships

### DIFF
--- a/src-python/trp/trp2.py
+++ b/src-python/trp/trp2.py
@@ -662,7 +662,9 @@ class TDocument():
             block_type_enum: TextractBlockTypes = None,    #type: ignore
             page: TBlock = None) -> List[TBlock]:    #type: ignore
         table_list: List[TBlock] = list()
-        if page and page.relationships:
+        if page:
+            if not page.relationships:
+                return table_list
             block_list = list(self.relationships_recursive(page))
             if block_type_enum:
                 return self.filter_blocks_by_type(block_list=block_list, textract_block_type=[block_type_enum])


### PR DESCRIPTION
This fixes #155.

Instead of falling back to searching the entire document for blocks, the method now returns an empty list if the page passed in as an argument does not have any relationships.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
