### PR TITLE
Misc Python TRP bug-fixes

### DIFF
--- a/src-python/README.md
+++ b/src-python/README.md
@@ -264,11 +264,8 @@ cd amazon-textract-response-parser
 python -m venv virtualenv
 virtualenv/bin/activate
 
-python -m pip install pip --upgrade
-python -m pip install pytest
-python -m pip install setuptools
-python -m pip install tabulate
-python src-python\setup.py install
+python -m pip install --upgrade pip setuptools
+python -m pip install -e .[dev]
 pytest
 ```
 

--- a/src-python/setup.py
+++ b/src-python/setup.py
@@ -31,6 +31,9 @@ setup(name='amazon-textract-response-parser',
       version='1.0.2',
       description='Easily parse JSON returned by Amazon Textract.',
       install_requires=requirements,
+      extras_require={
+          "dev": ["pytest", "tabulate"]
+      },
       scripts=['bin/amazon-textract-pipeline'],
       long_description_content_type='text/markdown',
       long_description=read('README.md'),

--- a/src-python/tests/test_t_tables.py
+++ b/src-python/tests/test_t_tables.py
@@ -1,0 +1,54 @@
+# Python Built-Ins:
+import json
+import os
+
+# Local Dependencies:
+from trp.t_tables import ExecuteTableValidations, HeaderFooterType
+from trp.trp2 import TDocument, TDocumentSchema
+
+
+current_folder = os.path.dirname(os.path.realpath(__file__))
+
+
+def test_execute_table_validations():
+    """
+    GIVEN: The source document may include preceding empty pages
+    WHEN: When ExecuteTableValidations is called to propose table merge lists
+    THEN: The proposed merge list is still correct
+
+    https://github.com/aws-samples/amazon-textract-response-parser/issues/175
+    """
+    with open(os.path.join(current_folder, "data/gib_multi_tables_multi_page_sample.json")) as f:
+        j = json.load(f)
+    j["Blocks"].insert(
+        1,
+        {
+            "BlockType": "PAGE",
+            "Geometry": {
+                "BoundingBox": {"Width": 1.0, "Height": 1.0, "Left": 0.0, "Top": 0.0},
+                "Polygon": [
+                    {"X": 0, "Y": 0.0},
+                    {"X": 1.0, "Y": 0},
+                    {"X": 1.0, "Y": 1.0},
+                    {"X": 0.0, "Y": 1.0},
+                ]
+            },
+            "Id": "DUMMY-EMPTY-PAGE",
+            "Relationships": [{"Type": "CHILD", "Ids": []}],
+            "Page": 0,
+        },
+    )
+
+    t_document: TDocument = TDocumentSchema().load(j)
+    expected_merged_tables = [
+        ["4894d2ba-0479-4196-9cbd-c0fea4d28762", "b5e061ec-05be-48d5-83fc-6719fdd4397a"],
+        ["8bbc3f4f-0354-4999-a001-4585631bb7fe", "cf8e09a1-c317-40c1-9c45-e830e14167d5"],
+    ]
+
+    # Initial validation checks for the test case itself:
+    for merge in expected_merged_tables:
+        for tbl_id in merge:
+            assert t_document.get_block_by_id(tbl_id).block_type == "TABLE"
+
+    merge_list = ExecuteTableValidations(t_document, HeaderFooterType.NONE, accuracy_percentage=98)
+    assert merge_list == expected_merged_tables

--- a/src-python/tests/test_t_tables.py
+++ b/src-python/tests/test_t_tables.py
@@ -3,11 +3,41 @@ import json
 import os
 
 # Local Dependencies:
-from trp.t_tables import ExecuteTableValidations, HeaderFooterType
+from trp import Document
+from trp.t_tables import __compare_table_headers, ExecuteTableValidations, HeaderFooterType
 from trp.trp2 import TDocument, TDocumentSchema
 
 
 current_folder = os.path.dirname(os.path.realpath(__file__))
+
+
+def test_table_header_compare():
+    """__compare_table_headers correctly matches between tables
+
+    https://github.com/aws-samples/amazon-textract-response-parser/issues/86
+    """
+    with open(os.path.join(current_folder, "data/gib_multi_tables_multi_page_sample.json")) as f:
+        j = json.load(f)
+    doc = Document(j)
+    # Load 2 tables with same column count:
+    test_table_1_id = "4894d2ba-0479-4196-9cbd-c0fea4d28762"
+    test_table_1 = doc.pages[0].tables[0]
+    test_table_2_id = "b5e061ec-05be-48d5-83fc-6719fdd4397a"
+    test_table_2 = doc.pages[1].tables[1]
+    assert test_table_1.id == test_table_1_id
+    assert test_table_2.id == test_table_2_id
+
+    # compare_table_headers should return false (different text):
+    assert __compare_table_headers(test_table_1, test_table_2) is False
+
+    # Overwrite the header text to match between the two tables:
+    for ix, cell in enumerate(test_table_1.rows[0].cells):
+        cell.text = f"DUMMY TEXT {ix}"
+    for ix, cell in enumerate(test_table_2.rows[0].cells):
+        cell.text = f"DUMMY TEXT {ix}"
+
+    # compare_table_headers should return true because the text matches:
+    assert __compare_table_headers(test_table_1, test_table_2) is True
 
 
 def test_execute_table_validations():

--- a/src-python/tests/test_t_tables.py
+++ b/src-python/tests/test_t_tables.py
@@ -21,7 +21,7 @@ def test_execute_table_validations():
     with open(os.path.join(current_folder, "data/gib_multi_tables_multi_page_sample.json")) as f:
         j = json.load(f)
     j["Blocks"].insert(
-        1,
+        0,
         {
             "BlockType": "PAGE",
             "Geometry": {
@@ -34,7 +34,7 @@ def test_execute_table_validations():
                 ]
             },
             "Id": "DUMMY-EMPTY-PAGE",
-            "Relationships": [{"Type": "CHILD", "Ids": []}],
+            "Relationships": [],
             "Page": 0,
         },
     )

--- a/src-python/tests/test_trp2.py
+++ b/src-python/tests/test_trp2.py
@@ -173,6 +173,39 @@ def test_custom_page_orientation(json_response):
         assert page.custom['PageOrientationBasedOnWords']
 
 
+def test_empty_page_orientation():
+    """
+    GIVEN: an empty page
+    WHEN: orientation is calculated
+    THEN: the tagged orientation should be 0 degrees
+
+    https://github.com/aws-samples/amazon-textract-response-parser/issues/156
+    """
+    j = {
+        "DocumentMetadata": {"Pages": 1},
+        "Blocks": [
+            {
+                "BlockType": "PAGE",
+                "Geometry": {
+                    "BoundingBox": {"Width": 1.0, "Height": 1.0, "Left": 0.0, "Top": 0.0},
+                    "Polygon": [
+                        {"X": 0, "Y": 0.0},
+                        {"X": 1.0, "Y": 0},
+                        {"X": 1.0, "Y": 1.0},
+                        {"X": 0.0, "Y": 1.0},
+                    ]
+                },
+                "Id": "DUMMY-EMPTY-PAGE",
+                "Relationships": [{"Type": "CHILD", "Ids": []}],
+                "Page": 0,
+            }
+        ],
+    }
+    t_document: t2.TDocument = t2.TDocumentSchema().load(j)    #type: ignore
+    t_document = add_page_orientation(t_document)
+    assert t_document.pages[0].custom["PageOrientationBasedOnWords"] == 0
+
+
 def test_filter_blocks_by_type():
     block_list = [t2.TBlock(id="1", block_type=t2.TextractBlockTypes.WORD.name)]
     assert t2.TDocument.filter_blocks_by_type(block_list=block_list,

--- a/src-python/tests/test_trp2.py
+++ b/src-python/tests/test_trp2.py
@@ -476,6 +476,44 @@ def test_block_id_map():
         assert tdoc.block_id_map(t2.TextractBlockTypes.LINE)['5ff46696-e06e-4577-ac3f-32a1ffde3290'] == 21    #a line
 
 
+def test_block_id_map_no_content():
+    """
+    GIVEN: a document that doesn't include any content of a particular block type
+    WHEN: TDocument is created
+    THEN: all BlockTypes' `block_id_map`s are still created
+    """
+    j = {
+        "DocumentMetadata": {"Pages": 1},
+        "Blocks": [
+            {
+                "BlockType": "PAGE",
+                "Geometry": {
+                    "BoundingBox": {"Width": 1.0, "Height": 1.0, "Left": 0.0, "Top": 0.0},
+                    "Polygon": [
+                        {"X": 0, "Y": 0.0},
+                        {"X": 1.0, "Y": 0},
+                        {"X": 1.0, "Y": 1.0},
+                        {"X": 0.0, "Y": 1.0},
+                    ]
+                },
+                "Id": "DUMMY-PAGE-1",
+            }
+        ],
+    }
+    tdoc: t2.TDocument = t2.TDocumentSchema().load(j)    #type: ignore
+    assert len(tdoc.block_id_map(t2.TextractBlockTypes.PAGE)) == 1
+    assert len(tdoc.block_id_map(t2.TextractBlockTypes.LINE)) == 0
+    assert len(tdoc.block_id_map(t2.TextractBlockTypes.SELECTION_ELEMENT)) == 0
+    assert len(tdoc.block_id_map(t2.TextractBlockTypes.WORD)) == 0
+    assert len(tdoc.block_id_map(t2.TextractBlockTypes.SIGNATURE)) == 0
+    assert len(tdoc.block_id_map(t2.TextractBlockTypes.TABLE)) == 0
+    assert len(tdoc.block_id_map(t2.TextractBlockTypes.CELL)) == 0
+    assert len(tdoc.block_id_map(t2.TextractBlockTypes.MERGED_CELL)) == 0
+    assert len(tdoc.block_id_map(t2.TextractBlockTypes.KEY_VALUE_SET)) == 0
+    assert len(tdoc.block_id_map(t2.TextractBlockTypes.QUERY)) == 0
+    assert len(tdoc.block_id_map(t2.TextractBlockTypes.QUERY_RESULT)) == 0
+
+
 def test_block_map():
     p = os.path.dirname(os.path.realpath(__file__))
     with open(os.path.join(p, "data/employment-application.json")) as f:

--- a/src-python/trp/t_pipeline.py
+++ b/src-python/trp/t_pipeline.py
@@ -141,8 +141,12 @@ def add_page_orientation(t_document: t2.TDocument) -> t2.TDocument:
         words = t2.TDocument.filter_blocks_by_type(
             block_list=t_document.get_child_relations(page=page),
             textract_block_type=[t2.TextractBlockTypes.WORD, t2.TextractBlockTypes.LINE])
-        orientation = statistics.mode(
-            [round(__get_degree_from_polygon(w.geometry.polygon)) for w in words if w.geometry and w.geometry.polygon])
+        word_orientations = [
+            round(__get_degree_from_polygon(w.geometry.polygon))
+            for w in words if w.geometry and w.geometry.polygon
+        ]
+        # (statistics.mode throws StatisticsError for empty lists)
+        orientation = statistics.mode(word_orientations) if word_orientations else 0
         if page.custom:
             page.custom['PageOrientationBasedOnWords'] = orientation
         else:

--- a/src-python/trp/t_tables.py
+++ b/src-python/trp/t_tables.py
@@ -86,25 +86,17 @@ def ExecuteTableValidations(t_doc: t2.TDocument, header_footer_type: HeaderFoote
     """
     Invoke validations for first and last tables on all pages recursively
     """
-    page_compare_proc = 0
     table_ids_to_merge = {}
     table_ids_merge_list = []
     from trp.t_pipeline import order_blocks_by_geo
     ordered_doc = order_blocks_by_geo(t_doc)
     trp_doc = trp.Document(TDocumentSchema().dump(ordered_doc))
 
-    for current_page in trp_doc.pages:
-
-        if (page_compare_proc >= len(trp_doc.pages) - 1):
-            break
-        if len(current_page.tables) == 0:
-            page_compare_proc += 1
-            break
+    for ix_page, current_page in enumerate(trp_doc.pages[:-1]):
+        next_page = trp_doc.pages[ix_page + 1]
+        if not (current_page.tables and next_page.tables):  # Note in Python, bool([]) = False
+            continue
         current_page_table = current_page.tables[len(current_page.tables) - 1]
-        next_page = trp_doc.pages[page_compare_proc + 1]
-        if len(next_page.tables) == 0:
-            page_compare_proc += 1
-            break
         next_page_table = next_page.tables[0]
         result_1 = __validate_objects_between_tables(current_page, current_page_table, next_page, next_page_table,
                                                      header_footer_type)
@@ -122,5 +114,4 @@ def ExecuteTableValidations(t_doc: t2.TDocument, header_footer_type: HeaderFoote
                             table_ids_merge_list.append([current_page_table.id, next_page_table.id])
                     else:
                         table_ids_merge_list.append([current_page_table.id, next_page_table.id])
-        page_compare_proc += 1
     return table_ids_merge_list

--- a/src-python/trp/t_tables.py
+++ b/src-python/trp/t_tables.py
@@ -50,13 +50,11 @@ def __compare_table_column_numbers(table_1, table_2):
 
 def __compare_table_headers(table_1, table_2):
     """
-    Step 2_2: Comparing table header (first row) values on each table
+    Step 2_2: Comparing table header (first row) text on each table
     """
-    col_num = len(table_1.rows[0].cells)
-    for i in range(0, col_num - 1):
-        if table_1.rows[0].cells[i] != table_2.rows[0].cells[i]:
-            return False
-    return True
+    headers_1 = [cell.text.strip() if cell.text else "" for cell in table_1.rows[0].cells]
+    headers_2 = [cell.text.strip() if cell.text else "" for cell in table_2.rows[0].cells]
+    return headers_1 == headers_2
 
 
 def __calculate_percentage_difference(measure_1, measure_2):

--- a/src-python/trp/trp2.py
+++ b/src-python/trp/trp2.py
@@ -636,8 +636,15 @@ class TDocument():
 
     @property
     def pages(self) -> List[TBlock]:
-        page_blocks = self.block_map(TextractBlockTypes.PAGE).values()
-        page_blocks = sorted(page_blocks, key=lambda item: item.page)
+        page_blocks = self.filter_blocks_by_type(
+            self.blocks,
+            textract_block_type=[TextractBlockTypes.PAGE],
+        )
+        # We'd like to return pages in explicitly-specified order where appropriate, but some
+        # (e.g. older) Textract API responses may not tag every PAGE block with a `Page` number,
+        # and `sorted()` will fail if we try to compare numbers vs `None`:
+        if all(block.page is not None for block in page_blocks):
+            page_blocks = sorted(page_blocks, key=lambda item: item.page)
         return page_blocks
 
     @staticmethod

--- a/src-python/trp/trp2.py
+++ b/src-python/trp/trp2.py
@@ -668,8 +668,9 @@ class TDocument():
             self,
             block_type_enum: TextractBlockTypes = None,    #type: ignore
             page: TBlock = None) -> List[TBlock]:    #type: ignore
-        table_list: List[TBlock] = list()
-        if page and page.relationships:
+        if page:
+            if not page.relationships:
+                return list()
             block_list = list(self.relationships_recursive(page))
             if block_type_enum:
                 return self.filter_blocks_by_type(block_list=block_list, textract_block_type=[block_type_enum])
@@ -677,12 +678,13 @@ class TDocument():
                 return block_list
         else:
             if self.blocks:
+                block_list: List[TBlock] = list()
                 for b in self.blocks:
                     if block_type_enum and b.block_type == block_type_enum.name:
-                        table_list.append(b)
+                        block_list.append(b)
                     if not block_type_enum:
-                        table_list.append(b)
-                return table_list
+                        block_list.append(b)
+                return block_list
             else:
                 return list()
 

--- a/src-python/trp/trp2.py
+++ b/src-python/trp/trp2.py
@@ -47,6 +47,18 @@ class TextractBlockTypes(Enum):
     QUERY_RESULT = auto()
     MERGED_CELL = auto()
     SIGNATURE = auto()
+    TABLE_TITLE = auto()
+    TABLE_FOOTER = auto()
+    LAYOUT_FIGURE = auto()
+    LAYOUT_FOOTER = auto()
+    LAYOUT_HEADER = auto()
+    LAYOUT_KEY_VALUE = auto()
+    LAYOUT_LIST = auto()
+    LAYOUT_PAGE_NUMBER = auto()
+    LAYOUT_SECTION_HEADER = auto()
+    LAYOUT_TABLE = auto()
+    LAYOUT_TEXT = auto()
+    LAYOUT_TITLE = auto()
 
 
 @dataclass
@@ -462,11 +474,15 @@ class TDocument():
         '''
         self._block_id_maps: Dict[str, typing.Dict[str, int]] = dict()
         self._block_id_maps['ALL'] = dict()
+        # Initialise maps for all expected block types:
+        for block_type in TextractBlockTypes:
+            self._block_id_maps[block_type.name] = dict()
         if self.blocks != None:
             for blk_i, blk in enumerate(self.blocks):
                 try:
                     self._block_id_maps[blk.block_type][blk.id] = blk_i
                 except KeyError:
+                    # ...but catch any unexpected block types we observe also:
                     self._block_id_maps[blk.block_type] = dict()
                     self._block_id_maps[blk.block_type][blk.id] = blk_i
 


### PR DESCRIPTION
**Issue #, if available:** #175, #156, #155, #153, #86

**Description of changes:**

Looking to tidy up a few quick-fix bugs in the Python library

- Explicitly specify the dev dependencies for Python TRP in `setup.py`, rather than manual install instructions in the README
- Fix #175 where encountering an empty or table-less page would cause ExecuteTableValidations to stop searching for merge-able tables in the rest of the document
- Fix #156 where trying to calculate the orientation of an empty page (containing no words) threw a `StatisticsError`
- Fix #155 where calling `get_blocks_by_type` specifically on an empty page would fetch matching blocks from the whole document
- Resolve *part* of inconsistency reported in #153, but probably not the whole issue
- Fix #86 `__compare_table_headers` always returning false

<br/>

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.