### PR TITLE
`TGeometry.rotate`: Pass degrees to `TPoint.rotate`

### DIFF
--- a/src-python/trp/trp2.py
+++ b/src-python/trp/trp2.py
@@ -270,7 +270,7 @@ class TGeometry():
 
     def rotate(self, origin: TPoint = TPoint(0, 0), degrees: float = 180.0):
         self.bounding_box.rotate(origin=origin, degrees=degrees)
-        [p.rotate(origin_x=origin.x, origin_y=origin.y) for p in self.polygon]
+        [p.rotate(origin_x=origin.x, origin_y=origin.y, degrees=degrees) for p in self.polygon]
 
     def scale(self, doc_width=None, doc_height=None):
         self.bounding_box.scale(doc_width=doc_width, doc_height=doc_height)


### PR DESCRIPTION
There was a bug where `TGeometry.rotate` didn't pass the `degrees` parameter to `TPoint.rotate`, meaning that calls to `TGeometry.rotate` (and `TDocument.rotate`) only ever rotated the polygon by 180 degrees.

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
